### PR TITLE
docs: align Python SDK chat_stream examples with event payloads

### DIFF
--- a/docs/sdks/python-sdk.md
+++ b/docs/sdks/python-sdk.md
@@ -69,9 +69,12 @@ formation = FormationClient(
 ```python
 # Streaming chat (recommended)
 for event in formation.chat_stream({"message": "Hello!"}, user_id="user_123"):
-    if event.get("type") == "text":
-        print(event.get("text"), end="", flush=True)
-    elif event.get("type") == "done":
+    if event.get("event") == "message":
+        data = json.loads(event.get("data", "{}"))
+        content = data.get("token", {}).get("content")
+        if content:
+            print(content, end="", flush=True)
+    elif event.get("event") == "done":
         break
 ```
 
@@ -193,6 +196,7 @@ For async/await usage:
 
 ```python
 import asyncio
+import json
 from muxi import AsyncFormationClient
 
 async def main():
@@ -204,9 +208,12 @@ async def main():
 
     # Async streaming
     async for event in await formation.chat_stream({"message": "Hello!"}, user_id="user_123"):
-        if event.get("type") == "text":
-            print(event.get("text"), end="", flush=True)
-        elif event.get("type") == "done":
+        if event.get("event") == "message":
+            data = json.loads(event.get("data", "{}"))
+            content = data.get("token", {}).get("content")
+            if content:
+                print(content, end="", flush=True)
+        elif event.get("event") == "done":
             break
 
 asyncio.run(main())
@@ -302,6 +309,7 @@ Environment variable `MUXI_DEBUG=1` also enables debug logging.
 ### Chat Bot
 
 ```python
+import json
 from muxi import FormationClient
 
 formation = FormationClient(
@@ -316,15 +324,21 @@ while True:
         break
 
     print("Assistant: ", end="")
-    for event in formation.chat_stream({"message": user_input}, user_id="user_123"):
-        if event.get("type") == "text":
-            print(event.get("text"), end="", flush=True)
+    for event in formation.chat_stream({"message": "Hello!"}, user_id="user_123"):
+        if event.get("event") == "message":
+            data = json.loads(event.get("data", "{}"))
+            content = data.get("token", {}).get("content")
+            if content:
+                print(content, end="", flush=True)
+        elif event.get("event") == "done":
+            break
     print()
 ```
 
 ### With Session Persistence
 
 ```python
+import json
 from muxi import FormationClient
 
 formation = FormationClient(
@@ -345,10 +359,15 @@ while True:
         {"message": user_input, "session_id": session_id},
         user_id="user_123"
     ):
-        if event.get("type") == "text":
-            print(event.get("text"), end="", flush=True)
-        elif event.get("session_id"):
-            session_id = event.get("session_id")
+    if event.get("event") == "message":
+        data = json.loads(event.get("data", "{}"))
+        content = data.get("token", {}).get("content")
+        if content:
+            print(content, end="", flush=True)
+        if session_id is None:
+            session_id = data.get("token", {}).get("session_id")
+    elif event.get("event") == "done":
+        break
     print()
 ```
 


### PR DESCRIPTION
# Summary
Update Python SDK streaming examples to parse message events from the current chat_stream payload.

# Why
The previous docs showed the older type / text shape instead of the current event / data structure.

# Changes
1. Replace the older type / text example with event == "message"
2. Parse JSON from data
3. Print token content from the message payload
4. Continue stopping on the done event