### PR TITLE
docs: document runtime 1.20260713.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,50 @@
 > - [OneLLM Releases](https://github.com/muxi-ai/onellm/releases)
 > - [FAISSx Releases](https://github.com/muxi-ai/faissx/releases)
 
+## July 2026
+
+### FAISSx v0.20260708.0
+
+#### Hot-path latency floors removed (~220× faster sequential adds)
+
+- **Every server operation carried a ~100ms latency floor**: the server's task worker polled for results with a 100ms sleep, so even a microsecond FAISS search took 100ms+. Results are now signalled via a condition variable, returning as soon as the work finishes.
+- **Persistence moved off the request path**: the server previously rewrote the entire index to disk synchronously after every mutation, blocking all clients. Writes are now debounced (default 5s, `FAISSX_PERSIST_INTERVAL`, `0` restores synchronous mode), performed atomically by a background thread, and flushed on shutdown. Combined with the polling fix, a sequential add workload went from 103ms to 0.47ms per add.
+- **Hot-path trims**: debug logging no longer stringifies full vector payloads when disabled, and the client stops re-applying ZMQ socket options on every request.
+
+#### Index type coverage and reliability fixes
+
+- **Server accepts standard FAISS descriptor strings** (`SQ8`, `IVF50,PQ8x8`, OPQ chains, ...) via an `index_factory` fallback instead of rejecting anything without a bespoke handler; remote `IndexScalarQuantizer` now auto-trains on first add to match local-mode behavior.
+- **Test suite repaired and made hermetic** (81/81 passing, from 20 failures + 7 errors): tests now run against a server started from the source tree on a dynamic port instead of whatever was listening on the default port, with client-singleton state reset between tests.
+
+### OneLLM v0.20260708.1
+
+#### Single-pass unicode cleaning on the streaming hot path
+
+- **Per-chunk streaming overhead cut 4.4×** (6.7 µs → 1.5 µs): `clean_unicode_artifacts()` — run on every response object and every streaming chunk — was ~70% of per-chunk overhead, rebuilding a 60-entry replacement dict per call and applying it as 60 sequential `str.replace` passes. Now an `isascii()` fast path skips cleaning entirely for ASCII output, and non-ASCII text is cleaned by one compiled regex with a per-match callback. Output is byte-identical (verified across 253 generated cases).
+- **A 300-chunk streamed response** drops from ~2 ms to ~0.45 ms of library CPU time; non-streaming request overhead −31%.
+
+### OneLLM v0.20260708.0
+
+#### Lazy provider loading
+
+- **`import onellm` no longer imports all 27 provider modules**: provider modules load on first use, cutting import time from ~190 ms to ~95–120 ms. The heaviest saving: `vertexai` no longer pulls `google-auth` + `requests` into every process that never touches Vertex AI.
+- **Public API unchanged**: `from onellm.providers import OpenAIProvider` still works (resolved lazily via PEP 562), class identity is preserved, and `register_provider()` for custom providers behaves as before.
+- **Clearer missing-dependency errors**: requesting a provider whose optional dependency is not installed raises `ImportError` naming the dependency, instead of a generic "not supported" `ValueError`. `list_providers()` now always lists every built-in.
+
+#### Provider instance memoization
+
+- **`get_provider("name")` returns a cached instance** instead of rebuilding config + retry state on every request (~11× faster resolution, multiplied for fallback chains which instantiate one provider per model per request).
+- **Automatic invalidation**: `set_api_key()` / `update_provider_config()` transparently produce a fresh instance via a config version counter; `clear_provider_cache()` is the escape hatch for direct config mutation. Calls with kwargs bypass the cache entirely.
+
+#### Bug fix: per-call kwargs leaked into global config
+
+- **`get_provider_config()` now returns a deep copy**: previously it returned the live global dict, so constructor kwargs like `timeout=5` merged by a provider's `__init__` permanently changed global configuration for all subsequent requests.
+
+#### Hot-path trims
+
+- **Message `deepcopy` skipped when response caching is disabled** (the default), provider-name regex precompiled, and OpenAI streaming no longer computes a fallback timestamp per chunk.
+- **Test-suite hardening**: three pre-existing test-isolation bugs (a config leak in an autouse fixture, mocks patching the wrong module binding, and patcher leaks on setup failure) fixed; the provider test directory now passes in isolation.
+
 ## June 2026
 
 ### Runtime v0.20260619.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,120 @@
 
 ## July 2026
 
+July launches MUXI V1: Runtime, Server, CLI, and all 12 SDKs move together to
+the `1.x` release line, establishing a stable generation of contracts across
+formation execution, APIs, and client integrations.
+
+### Runtime, Server, CLI & SDKs v1.20260713.0
+
+#### Response envelope UI widgets
+
+- **Chat responses can now carry typed UI widgets.** A streamed response emits an
+  optional `ui` SSE event at end-of-turn (just before `done`) carrying `options`,
+  `action_link`, and `mcp_resource` widgets. The runtime never renders them;
+  clients render what they understand and ignore the rest, with the response text
+  always carrying the fallback. Non-streaming response messages carry the same
+  optional `ui` array. See [Response UI Widgets](docs/reference/response-ui-widgets.md).
+- **All 12 SDKs surface widgets idiomatically**: Go decodes them into typed
+  `ChatChunk.UI`, TypeScript yields `{ type: "ui", ui: UIWidget[] }`, and the
+  other ten expose a `parse_ui_widgets` / `parseUiWidgets` helper.
+
+#### Idempotency keys for mutating requests
+
+- **`X-Muxi-Idempotency-Key` header** on chat, execute-trigger, and create-scheduled-job
+  requests replays the original 2xx response on retry instead of running the work
+  twice (24h TTL, single-flighted, streaming passes through untouched). The key is
+  echoed back on the response envelope as `request.idempotency_key`. All SDKs send
+  it automatically and surface the echoed value. See [Idempotency](docs/deep-dives/idempotency.md).
+
+#### Formation self-tuning state preserved across deploys
+
+- **The server now preserves `MUXI.md` and `PENDING-MUXI.md`** (the formation's
+  self-improvement state) across updates and rollbacks, alongside `memory.db`, so
+  redeploying code never discards what a formation has learned. See
+  [Self-Tuning](docs/concepts/self-tuning.md).
+
+#### CLI catch-up
+
+- **`muxi tuning show | pending | apply | dismiss`** to review and act on a
+  formation's self-improvement suggestions.
+- **`muxi knowledge rebuild`** to force-rebuild persistent per-agent knowledge trees.
+- **Formation validation** now covers knowledge sources (local `path` vs remote
+  `url` with supported schemes, and the `agent_tree.regenerate` mode), tuning, and
+  A2A auth blocks.
+
+#### Access control (Groups & RBAC)
+
+- **Group-based access control** via an auto-discovered `groups/` directory:
+  allow-list YAML with `inherits`, fnmatch globs, and a four-level `tools:
+  {allow, deny}` cascade. Membership now comes from a `middleware:` MCP server
+  (fail-closed), gated by an `rbac:` block. The pre-1.0 `server.auth` key and
+  `user_groups` table were **removed**. See [Access Control](docs/concepts/access-control.md).
+
+#### Proactiveness
+
+- **Formations can now initiate contact.** The `proactive:` block adds
+  notification routing (`POST /v1/notifications`, per-user channel state),
+  channels-as-transformers (bundled slack/telegram/discord/email templates),
+  heartbeats (active hours, `HEARTBEAT_OK` suppression), `SOUL.md` soul
+  documents, and nine built-in slash commands. See [Proactiveness](docs/concepts/proactiveness.md).
+
+#### Coding-agent delegation
+
+- **New `coding:` block and `delegate_coding` tool** hand coding tasks to an
+  external headless CLI (claude-code/droid/opencode/pi or a custom adapter) as
+  isolated, always-async background jobs. See [Coding-Agent Delegation](docs/concepts/coding-delegation.md).
+
+#### Trigger transformers
+
+- **Trigger results can reach external platforms** with no glue code via
+  `transformers/<name>.yaml` and `transformer:` / `webhook:` / `parse:` in
+  trigger frontmatter (template substitution, auth, retry, fallback). Response
+  UI widgets render natively on supporting channels. See [Triggers](docs/reference/triggers.md#transformers-outbound-routing).
+
+#### Knowledge: reasoning RAG + remote sources
+
+- **Reasoning RAG**: large documents index as hierarchical trees navigated at
+  query time - `retrieval: tree | tree-vector | hybrid`, gated by
+  `knowledge.reasoning_threshold`, with a `knowledge.tree` settings block and
+  persistent per-agent trees (`agent_tree:`). Falls back to vector on failure.
+- **Remote knowledge sources**: `url:` sources over `http(s)`, `s3`, `gs`, `az`,
+  `rsync(+ssh)`, `ftp`, `sftp`, `file`, with archive extraction (`extract:`),
+  scheduled re-sync (`schedule:` + `retry:`), incremental re-embedding, and an
+  on-demand `POST /v1/agents/{id}/knowledge/sync`. See [Knowledge](docs/reference/knowledge.md).
+
+#### Memory platform
+
+- **Scopes** (`user` / `group` / `formation`, grant-gated shared writes),
+  **ingestion API** (`POST /v1/memories`, batch, distillery), an **event
+  substrate** (immutable events, provenance, `POST /v1/memory/{rebuild,backfill,forget}`,
+  decay), and a **knowledge graph + Captain's Log + lessons loop**, plus
+  compaction/pruning/index/lint lifecycle blocks. See [Memory](docs/reference/memory.md).
+
+#### Model selection & workflows
+
+- **Hierarchical model selection** (`llm.models` → agent → SOP/trigger/skill
+  frontmatter → per-step) with `llm.aliases`. See [LLM Providers](docs/concepts/llm-providers.md).
+- **Workflow-level replanning** (`overlord.workflow.replanning`, off by default).
+  See [Workflows](docs/reference/workflows.md#workflow-level-replanning).
+
+#### Tools, skills & A2A
+
+- **Built-in tools**: `watch_job`, `recall_history`, `record_lesson`,
+  `get_artifact*`, `delegate_coding`; unified `allow`/`deny` tool vocabulary
+  with agent-attachment overrides and an `mcp.watch` block. See [Tools](docs/reference/tools.md).
+- **Artifact memory**: everything `generate_file` produces is now persisted
+  (versioned, encrypted, user-scoped) and recallable. See [Artifacts](docs/concepts/artifacts.md).
+- **Bundled `compute` skill** (code-as-reasoning in the RCE sandbox). See [Skills](docs/reference/skills.md).
+- **A2A auth** adds outbound `oauth2`, bidirectional `hmac`, and inbound
+  `openid`. Outbound credentials now use canonical `id` entries matched by
+  service `url`; legacy `service_id` remains accepted but is deprecated. See
+  [A2A Services](docs/reference/a2a.md#authentication).
+
+#### SDK version
+
+- All 12 SDK version sources were reset to `1.0.0` to open the 1.x release train.
+
 ### FAISSx v0.20260708.0
 
 #### Hot-path latency floors removed (~220× faster sequential adds)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -41,11 +41,15 @@ description: Complete guide to building AI agents with MUXI
   * [Async Processing](concepts/async.md)
   * [Triggers & Webhooks](concepts/triggers-and-webhooks.md)
   * [Scheduled Tasks](concepts/scheduled-tasks.md)
+  * [Proactiveness](concepts/proactiveness.md)
+  * [Coding-Agent Delegation](concepts/coding-delegation.md)
+  * [Self-Tuning](concepts/self-tuning.md)
   * [SOPs](concepts/standard-operating-procedures.md)
 
 * Production
   * [LLM Providers](concepts/llm-providers.md)
   * [Secrets & Security](concepts/secrets-and-security.md)
+  * [Access Control](concepts/access-control.md)
   * [User Credentials](concepts/user-credentials.md)
   * [Multi-Tenancy](concepts/multi-tenancy.md)
   * [Multi-Identity Users](concepts/multi-identity.md)
@@ -138,6 +142,7 @@ description: Complete guide to building AI agents with MUXI
   * [Triggers](reference/triggers.md)
   * [Approvals](reference/approvals.md)
   * [Secrets](reference/secrets.md)
+  * [Response UI Widgets](reference/response-ui-widgets.md)
 
 * [Examples](reference/examples.md)
 
@@ -157,6 +162,7 @@ description: Complete guide to building AI agents with MUXI
 * [Event Types](deep-dives/observability-events.md)
 * [Security Model](deep-dives/security-model.md)
 * [Resilience](deep-dives/resilience.md)
+* [Idempotency](deep-dives/idempotency.md)
 * [Multi-Server Memory](deep-dives/multi-server-memory.md)
 
 ## Miscellaneous

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,160 @@ description: Release history and updates for MUXI
 > - [OneLLM Releases](https://github.com/muxi-ai/onellm/releases)
 > - [FAISSx Releases](https://github.com/muxi-ai/faissx/releases)
 
+## July 2026
+
+### Runtime, Server, CLI & SDKs v1.20260713.0
+
+#### Response envelope UI widgets
+
+- **Chat responses can now carry typed UI widgets.** A streamed response emits an
+  optional `ui` SSE event at end-of-turn (just before `done`) carrying `options`,
+  `action_link`, and `mcp_resource` widgets. The runtime never renders them;
+  clients render what they understand and ignore the rest, with the response text
+  always carrying the fallback. Non-streaming response messages carry the same
+  optional `ui` array. See [Response UI Widgets](reference/response-ui-widgets.md).
+- **All 12 SDKs surface widgets idiomatically**: Go decodes them into typed
+  `ChatChunk.UI`, TypeScript yields `{ type: "ui", ui: UIWidget[] }`, and the
+  other ten expose a `parse_ui_widgets` / `parseUiWidgets` helper.
+
+#### Idempotency keys for mutating requests
+
+- **`X-Muxi-Idempotency-Key` header** on chat, execute-trigger, and create-scheduled-job
+  requests replays the original 2xx response on retry instead of running the work
+  twice (24h TTL, single-flighted, streaming passes through untouched). The key is
+  echoed back on the response envelope as `request.idempotency_key`. All SDKs send
+  it automatically and surface the echoed value. See [Idempotency](deep-dives/idempotency.md).
+
+#### Formation self-tuning state preserved across deploys
+
+- **The server now preserves `MUXI.md` and `PENDING-MUXI.md`** (the formation's
+  self-improvement state) across updates and rollbacks, alongside `memory.db`, so
+  redeploying code never discards what a formation has learned. See
+  [Self-Tuning](concepts/self-tuning.md).
+
+#### CLI catch-up
+
+- **`muxi tuning show | pending | apply | dismiss`** to review and act on a
+  formation's self-improvement suggestions.
+- **`muxi knowledge rebuild`** to force-rebuild persistent per-agent knowledge trees.
+- **Formation validation** now covers knowledge sources (local `path` vs remote
+  `url` with supported schemes, and the `agent_tree.regenerate` mode), tuning, and
+  A2A auth blocks.
+
+#### Access control (Groups & RBAC)
+
+- **Group-based access control** via an auto-discovered `groups/` directory:
+  allow-list YAML with `inherits`, fnmatch globs, and a four-level `tools:
+  {allow, deny}` cascade. Membership now comes from a `middleware:` MCP server
+  (fail-closed), gated by an `rbac:` block. The pre-1.0 `server.auth` key and
+  `user_groups` table were **removed**. See [Access Control](concepts/access-control.md).
+
+#### Proactiveness
+
+- **Formations can now initiate contact.** The `proactive:` block adds
+  notification routing (`POST /v1/notifications`, per-user channel state),
+  channels-as-transformers (bundled slack/telegram/discord/email templates),
+  heartbeats (active hours, `HEARTBEAT_OK` suppression), `SOUL.md` soul
+  documents, and nine built-in slash commands. See [Proactiveness](concepts/proactiveness.md).
+
+#### Coding-agent delegation
+
+- **New `coding:` block and `delegate_coding` tool** hand coding tasks to an
+  external headless CLI (claude-code/droid/opencode/pi or a custom adapter) as
+  isolated, always-async background jobs. See [Coding-Agent Delegation](concepts/coding-delegation.md).
+
+#### Trigger transformers
+
+- **Trigger results can reach external platforms** with no glue code via
+  `transformers/<name>.yaml` and `transformer:` / `webhook:` / `parse:` in
+  trigger frontmatter (template substitution, auth, retry, fallback). Response
+  UI widgets render natively on supporting channels. See [Triggers](reference/triggers.md#transformers-outbound-routing).
+
+#### Knowledge: reasoning RAG + remote sources
+
+- **Reasoning RAG**: large documents index as hierarchical trees navigated at
+  query time - `retrieval: tree | tree-vector | hybrid`, gated by
+  `knowledge.reasoning_threshold`, with a `knowledge.tree` settings block and
+  persistent per-agent trees (`agent_tree:`). Falls back to vector on failure.
+- **Remote knowledge sources**: `url:` sources over `http(s)`, `s3`, `gs`, `az`,
+  `rsync(+ssh)`, `ftp`, `sftp`, `file`, with archive extraction (`extract:`),
+  scheduled re-sync (`schedule:` + `retry:`), incremental re-embedding, and an
+  on-demand `POST /v1/agents/{id}/knowledge/sync`. See [Knowledge](reference/knowledge.md).
+
+#### Memory platform
+
+- **Scopes** (`user` / `group` / `formation`, grant-gated shared writes),
+  **ingestion API** (`POST /v1/memories`, batch, distillery), an **event
+  substrate** (immutable events, provenance, `POST /v1/memory/{rebuild,backfill,forget}`,
+  decay), and a **knowledge graph + Captain's Log + lessons loop**, plus
+  compaction/pruning/index/lint lifecycle blocks. See [Memory](reference/memory.md).
+
+#### Model selection & workflows
+
+- **Hierarchical model selection** (`llm.models` → agent → SOP/trigger/skill
+  frontmatter → per-step) with `llm.aliases`. See [LLM Providers](concepts/llm-providers.md).
+- **Workflow-level replanning** (`overlord.workflow.replanning`, off by default).
+  See [Workflows](reference/workflows.md#workflow-level-replanning).
+
+#### Tools, skills & A2A
+
+- **Built-in tools**: `watch_job`, `recall_history`, `record_lesson`,
+  `get_artifact*`, `delegate_coding`; unified `allow`/`deny` tool vocabulary
+  with agent-attachment overrides and an `mcp.watch` block. See [Tools](reference/tools.md).
+- **Artifact memory**: everything `generate_file` produces is now persisted
+  (versioned, encrypted, user-scoped) and recallable. See [Artifacts](concepts/artifacts.md).
+- **Bundled `compute` skill** (code-as-reasoning in the RCE sandbox). See [Skills](reference/skills.md).
+- **A2A auth** adds outbound `oauth2`, bidirectional `hmac`, and inbound
+  `openid`. Outbound credentials now use canonical `id` entries matched by
+  service `url`; legacy `service_id` remains accepted but is deprecated. See
+  [A2A Services](reference/a2a.md#authentication).
+
+#### SDK version
+
+- All 12 SDK version sources were reset to `1.0.0` to open the 1.x release train.
+
+### FAISSx v0.20260708.0
+
+#### Hot-path latency floors removed (~220× faster sequential adds)
+
+- **Every server operation carried a ~100ms latency floor**: the server's task worker polled for results with a 100ms sleep, so even a microsecond FAISS search took 100ms+. Results are now signalled via a condition variable, returning as soon as the work finishes.
+- **Persistence moved off the request path**: the server previously rewrote the entire index to disk synchronously after every mutation, blocking all clients. Writes are now debounced (default 5s, `FAISSX_PERSIST_INTERVAL`, `0` restores synchronous mode), performed atomically by a background thread, and flushed on shutdown. Combined with the polling fix, a sequential add workload went from 103ms to 0.47ms per add.
+- **Hot-path trims**: debug logging no longer stringifies full vector payloads when disabled, and the client stops re-applying ZMQ socket options on every request.
+
+#### Index type coverage and reliability fixes
+
+- **Server accepts standard FAISS descriptor strings** (`SQ8`, `IVF50,PQ8x8`, OPQ chains, ...) via an `index_factory` fallback instead of rejecting anything without a bespoke handler; remote `IndexScalarQuantizer` now auto-trains on first add to match local-mode behavior.
+- **Test suite repaired and made hermetic** (81/81 passing, from 20 failures + 7 errors): tests now run against a server started from the source tree on a dynamic port instead of whatever was listening on the default port, with client-singleton state reset between tests.
+
+### OneLLM v0.20260708.1
+
+#### Single-pass unicode cleaning on the streaming hot path
+
+- **Per-chunk streaming overhead cut 4.4×** (6.7 µs → 1.5 µs): `clean_unicode_artifacts()` — run on every response object and every streaming chunk — was ~70% of per-chunk overhead, rebuilding a 60-entry replacement dict per call and applying it as 60 sequential `str.replace` passes. Now an `isascii()` fast path skips cleaning entirely for ASCII output, and non-ASCII text is cleaned by one compiled regex with a per-match callback. Output is byte-identical (verified across 253 generated cases).
+- **A 300-chunk streamed response** drops from ~2 ms to ~0.45 ms of library CPU time; non-streaming request overhead −31%.
+
+### OneLLM v0.20260708.0
+
+#### Lazy provider loading
+
+- **`import onellm` no longer imports all 27 provider modules**: provider modules load on first use, cutting import time from ~190 ms to ~95–120 ms. The heaviest saving: `vertexai` no longer pulls `google-auth` + `requests` into every process that never touches Vertex AI.
+- **Public API unchanged**: `from onellm.providers import OpenAIProvider` still works (resolved lazily via PEP 562), class identity is preserved, and `register_provider()` for custom providers behaves as before.
+- **Clearer missing-dependency errors**: requesting a provider whose optional dependency is not installed raises `ImportError` naming the dependency, instead of a generic "not supported" `ValueError`. `list_providers()` now always lists every built-in.
+
+#### Provider instance memoization
+
+- **`get_provider("name")` returns a cached instance** instead of rebuilding config + retry state on every request (~11× faster resolution, multiplied for fallback chains which instantiate one provider per model per request).
+- **Automatic invalidation**: `set_api_key()` / `update_provider_config()` transparently produce a fresh instance via a config version counter; `clear_provider_cache()` is the escape hatch for direct config mutation. Calls with kwargs bypass the cache entirely.
+
+#### Bug fix: per-call kwargs leaked into global config
+
+- **`get_provider_config()` now returns a deep copy**: previously it returned the live global dict, so constructor kwargs like `timeout=5` merged by a provider's `__init__` permanently changed global configuration for all subsequent requests.
+
+#### Hot-path trims
+
+- **Message `deepcopy` skipped when response caching is disabled** (the default), provider-name regex precompiled, and OpenAI streaming no longer computes a fallback timestamp per chunk.
+- **Test-suite hardening**: three pre-existing test-isolation bugs (a config leak in an autouse fixture, mocks patching the wrong module binding, and patcher leaks on setup failure) fixed; the provider test directory now passes in isolation.
+
 ## June 2026
 
 ### Runtime v0.20260619.0
@@ -110,7 +264,7 @@ Recurring scheduled jobs were spawning a fresh one-time job on every firing inst
 
 #### Tool whitelist / blacklist filter on MCP servers (now documented)
 
-- **`tools.whitelist` / `tools.blacklist`** on any MCP `.afs` file — mutually exclusive, fnmatch globs, applied at registration so filtered tools are invisible to the LLM. See [Tools & MCP](concepts/tools-and-mcp.md#tool-filtering-whitelist--blacklist) and the [Add Tools guide](guides/add-mcp-tools.md#filter-the-tool-surface-whitelistblacklist).
+- **`tools.whitelist` / `tools.blacklist`** on any MCP `.afs` file — mutually exclusive in that release, fnmatch globs, applied at registration so filtered tools are invisible to the LLM. They are now aliases for `allow` / `deny`. See [Tools & MCP](concepts/tools-and-mcp.md#tool-filtering-allow--deny) and the [Add Tools guide](guides/add-mcp-tools.md#filter-the-tool-surface-allow--deny).
 
 ### OneLLM v0.20260502.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,10 @@ description: Release history and updates for MUXI
 
 ## July 2026
 
+July launches MUXI V1: Runtime, Server, CLI, and all 12 SDKs move together to
+the `1.x` release line, establishing a stable generation of contracts across
+formation execution, APIs, and client integrations.
+
 ### Runtime, Server, CLI & SDKs v1.20260713.0
 
 #### Response envelope UI widgets

--- a/docs/cli/cheatsheet.md
+++ b/docs/cli/cheatsheet.md
@@ -80,6 +80,25 @@ muxi chat --agent researcher "Find info on X"
 ```
 
 
+## Knowledge
+
+```bash
+# Force-rebuild persistent per-agent knowledge trees (running formation)
+muxi knowledge rebuild
+```
+
+
+## Self-Tuning
+
+```bash
+# Review the formation's self-improvement (tuning) state
+muxi tuning show        # Show the live MUXI.md
+muxi tuning pending     # Show the pending MUXI.md suggestion, if any
+muxi tuning apply       # Promote the pending suggestion to the live MUXI.md
+muxi tuning dismiss     # Discard the pending suggestion
+```
+
+
 ## Secrets
 
 ```bash

--- a/docs/concepts/access-control.md
+++ b/docs/concepts/access-control.md
@@ -1,0 +1,159 @@
+---
+title: Access Control (Groups & RBAC)
+description: Control who can reach a formation and which agents, tools, and SOPs each group can use
+---
+
+# Access Control (Groups & RBAC)
+
+## Who can do what, resolved on every request
+
+MUXI controls access with three pieces that work together:
+
+- **`groups/`** - YAML files defining permission sets (which agents, triggers,
+  SOPs, and MCP tools a group can reach).
+- **`middleware:`** - the single source of group membership: an MCP server you
+  supply that tags each inbound request with the caller's groups.
+- **`rbac:`** - the switch that decides whether membership is enforced and what
+  happens to a request with no groups.
+
+Permissions resolve once per request (behind a membership + resolution cache)
+and filter agent routing, direct agent addressing, workflow planning/execution,
+trigger firing (403), SOP matching, and each agent's per-server MCP tool surface.
+A denied agent behaves exactly like an unknown one - no information leak. A
+formation with no `groups/` directory is unaffected.
+
+> [!IMPORTANT]
+> The pre-1.0 `server.auth` key and the `user_groups` membership table have been
+> **removed**. Membership now comes only from the `middleware:` server; user-level
+> gating is `rbac.fallback: false` plus a middleware that returns no groups for
+> unknown users. A formation still carrying `server.auth` fails to load.
+
+
+## Group files
+
+A `groups/` directory activates permission filtering. Each file is one group;
+its id is the filename stem:
+
+```yaml
+# groups/support.yaml
+inherits: [base]          # optional, cycle-detected
+
+agents:                   # a plain list is an allow-list
+  - support-*             # fnmatch globs supported
+  - faq
+
+triggers:
+  - zendesk-*
+
+sops:
+  - customer-onboarding
+
+native_apps:
+  allow: ["support-console"]
+  deny: ["admin-*"]
+
+memory:
+  write:                  # grants for writing shared memory scopes
+    - "formation"
+```
+
+Across a user's groups, allows are unioned and any deny wins.
+
+### Cascading tool overrides
+
+One `tools: {allow, deny}` structure applies at four levels; the most specific
+wins, and `deny` is applied after `allow`:
+
+1. MCP registry catalog (`mcp.servers[].tools`)
+2. Agent attachment (`{id, tools}` on an agent's `mcp_servers`)
+3. Group per-server
+4. Group per-agent-per-server
+
+`tools: {deny: "*"}` hides a server from a group entirely.
+
+```yaml
+# groups/support.yaml
+mcp_servers:
+  web-search:
+    tools:
+      allow: ["search"]
+      deny: ["admin_*"]
+```
+
+Per-agent overrides live inside that agent's allow-list entry:
+
+```yaml
+agents:
+  - support:
+      web-search:
+        tools:
+          allow: ["search", "read-page"]
+```
+
+The separate `mcp:` group key is reserved for the `watch_job` quota:
+
+```yaml
+mcp:
+  watch:
+    max_concurrent: 4
+```
+
+`allow` / `deny` is the canonical vocabulary at every level; `whitelist` /
+`blacklist` remain accepted aliases.
+
+
+## Membership middleware
+
+Membership comes from a `middleware:` MCP server you run. It exposes exactly one
+tool named `middleware`, receives the full request payload (`user_id`,
+`message`, `attachments`, `metadata`, `route_class` - never `groups` inbound),
+and returns the same-shaped payload, optionally attaching `groups`, rewriting
+identity, or applying payload policy.
+
+```yaml
+middleware:
+  command: python           # stdio server
+  args: ["middleware.py"]
+  timeout: 5
+  # or an http server:
+  # url: https://rbac.internal/mcp
+  # headers: { Authorization: "Bearer ${{ secrets.RBAC_TOKEN }}" }
+```
+
+The pipeline runs after client-key auth, before any processing, on **all**
+authenticated inbound traffic (chat, audiochat, triggers, memory routes) and on
+internally-originated requests (heartbeat and scheduler jobs synthesize the same
+payload with `route_class: "heartbeat"` / `"scheduler"`). It is **fail-closed**:
+an error, timeout, or malformed response rejects the request with 403. There is
+no runtime-side caching of the middleware result - `timeout` is the only knob.
+
+A shipped one-file stdio template (`contributing/templates/middleware.py` in the
+runtime repo) resolves groups from a static map and doubles as a starting point.
+
+
+## The `rbac:` switch
+
+```yaml
+rbac:
+  active: auto              # auto = on iff groups/ has files; true = force on; false = kill switch
+  fallback: false           # reject no-group requests, or name a group whose permissions apply
+```
+
+- `active: true` without any `groups/` files fails the load.
+- `active: false` is a loud kill switch.
+- `fallback: <group_name>` must reference an existing group.
+- Dead config (`active` on + `fallback: false` + no `middleware`) fails the load.
+
+
+## Shared memory grants
+
+Writing formation- or group-scoped [memory](memory-system.md) requires a
+`memory.write` grant in the caller's group YAML (403 without one; globs
+supported). Conversation-derived extraction is always user-scoped.
+
+
+## Learn More
+
+- [Multi-Tenancy](multi-tenancy.md) - per-user isolation this builds on
+- [Memory System](memory-system.md) - memory scopes and shared-write grants
+- [Tools & MCP](tools-and-mcp.md) - the tool cascade in context

--- a/docs/concepts/artifacts.md
+++ b/docs/concepts/artifacts.md
@@ -136,44 +136,45 @@ System validates & executes
      ↓
 File captured
      ↓
-Artifact stored (with session ID)
+Artifact captured for the user
      ↓
 Unique ID assigned (art_ABC123)
 ```
 
 ### Storage
 
-Artifacts are organized by session:
+Artifact memory stores encrypted blobs under the configured local path and
+keeps searchable metadata in persistent memory. Storage is user-scoped rather
+than organized by chat session.
 
 ```
 artifacts/
-└── session_xyz/
-    ├── art_ABC123/
-    │   ├── file.pdf
-    │   └── metadata.json
-    └── art_DEF456/
-        ├── chart.png
-        └── metadata.json
+└── <user_id>/
+    └── <artifact_id_prefix>/
+        └── <artifact_id>.bin
 ```
 
 **Metadata includes:**
 - MIME type (application/pdf, image/png, etc.)
 - File size
 - Created timestamp
-- Session ID
-- Request ID that triggered creation
-- Original filename
+- Producing agent and conversation ID
+- Artifact name
+- Version, parent artifact, summary, tags, and checksum
 
 ### Cleanup
 
-Artifacts automatically expire:
+Retention is unlimited by default. Configure a positive duration in days to
+expire artifacts, with an hourly cleanup sweep:
 
 ```yaml
-artifact_retention: 7d      # Keep for 7 days
-cleanup_interval: 1h        # Check every hour
+artifacts:
+  retention:
+    policy: last_accessed
+    duration: 7
 ```
 
-Old artifacts are automatically purged to save storage.
+Use `last_updated` instead when reads should not extend retention.
 
 
 ## What Agents Can Generate
@@ -334,31 +335,77 @@ Response: "Here's your chart [Download PNG]"
 
 ## Configuration
 
-### Enable Artifact Generation
+The `artifacts:` block configures persistent artifact memory. Capture is enabled
+by default for formations with persistent memory. With no block, artifacts use
+local `./artifacts` storage, encryption is enabled, retention is unlimited, and
+the capture limit is 50 MB per artifact.
 
 ```yaml
 # formation.afs
 artifacts:
   enabled: true
-  max_file_size: 10485760      # 10 MB
-  execution_timeout: 30         # 30 seconds
-  allowed_formats:
-    - pdf
-    - png
-    - jpg
-    - csv
-    - json
+  storage:
+    type: local               # only shipped backend; other values fail load
+    path: ./artifacts
+  encryption:
+    enabled: true
+  retention:
+    policy: last_accessed     # last_accessed | last_updated
+    duration: 0               # days; 0 keeps artifacts forever
+  max_size_mb: 50
 ```
 
-### Storage Options
+
+## Artifact Memory
+
+Everything an agent produces through `generate_file` (local sandbox or RCE) is
+persisted automatically - versioned, user-scoped, encrypted, and
+retention-managed. There is no behavior change for agents; the data accumulates
+so it can be recalled later.
+
+- **Storage**: content is gzipped, then AES-256-GCM encrypted with a per-user
+  key derived (HKDF-SHA256) from an immutable `formation_instance_id`, kept in a
+  local blob store with SHA-256 checksums and a metadata row in the `artifacts`
+  table.
+- **Versioning**: producing an artifact with an existing name demotes the
+  previous head and chains it via `parent_id`; history blobs are retained.
+- **Retention**: `expires_at` is computed at capture from `artifacts.retention`;
+  an hourly sweep soft-deletes expired rows and prunes blobs.
+- **Safety**: capture is a tracked background task off the response path - every
+  failure is logged and swallowed, and secret-interpolated content is never
+  captured. S3 storage is rejected loudly at config time.
+
+### Retrieving artifacts
+
+Agents recall past artifacts through built-in tools, and the same data is
+available over REST:
+
+| Tool | Purpose |
+|------|---------|
+| `get_artifact` | Fetch an id with a 500-character preview, or search name/summary/tags with optional `category` (`limit` defaults to 5, max 20) |
+| `get_artifact_content` | Read decrypted text content by id, optionally selecting `version`; binary content is kept out of model context |
+| `get_artifact_history` | Walk the complete version chain from any version's id |
+
+| REST endpoint | Purpose |
+|---------------|---------|
+| `GET /v1/artifacts` | List the user's latest artifact versions |
+| `GET /v1/artifacts/{artifact_id}` | Read metadata and summary |
+| `GET /v1/artifacts/{artifact_id}/content` | Download decrypted content |
+| `GET /v1/artifacts/{artifact_id}/versions` | Read the version chain |
+
+All reads are user-scoped. A cross-user artifact id behaves as not found.
+Retrieval refreshes `last_accessed_at` and therefore extends expiry under the
+`last_accessed` retention policy. If artifact memory is unavailable, listing
+returns an empty collection and id reads return 404.
+
+The per-user Knowledge Index includes up to
+`memory.index.artifact_cap` artifacts (default 20), then points the agent to
+`get_artifact` for further search:
 
 ```yaml
-artifacts:
-  storage:
-    type: local               # or "s3", "azure-blob"
-    path: /var/muxi/artifacts
-    retention_days: 7
-    cleanup_enabled: true
+memory:
+  index:
+    artifact_cap: 20
 ```
 
 
@@ -366,30 +413,20 @@ artifacts:
 
 ### What's Protected
 
-✅ **System is protected from:**
-- Malicious code execution
-- Resource exhaustion
-- Network attacks
-- File system access
-- Data exfiltration
-
-✅ **User data is protected:**
-- Artifacts isolated per session
-- No cross-user access
-- Encrypted storage (optional)
-- Automatic expiration
+Artifact generation runs in the configured sandbox with import, path, time, and
+memory controls. Persistent artifact reads are isolated by user; cross-user IDs
+return not found. Local blobs are encrypted by default and integrity-checked
+with SHA-256.
 
 ### What Users Should Know
 
-⚠️ **Artifacts are temporary:**
-- Default retention: 7 days
-- Download important files
-- Not a backup solution
+- Retention is unlimited by default (`artifacts.retention.duration: 0`).
+- Set a positive duration in days to enable automatic expiration.
+- Artifact memory is not a replacement for an independent backup.
 
-⚠️ **Size limits exist:**
-- Max file size: 10 MB (default)
-- Large files may be rejected
-- Consider chunking or compression
+- The default capture limit is 50 MB per artifact
+  (`artifacts.max_size_mb`).
+- Larger files are returned to the user but skipped by artifact-memory capture.
 
 
 ## Common Use Cases

--- a/docs/concepts/coding-delegation.md
+++ b/docs/concepts/coding-delegation.md
@@ -1,0 +1,83 @@
+---
+title: Coding-Agent Delegation
+description: Delegate coding tasks to external headless coding CLIs as background work
+---
+
+# Coding-Agent Delegation
+
+## Hand coding tasks to an external CLI
+
+A formation can delegate coding work to an external headless coding CLI
+(claude-code, droid, opencode, pi, or your own adapter) as fire-and-collect
+background jobs. The agent calls one tool; MUXI runs the CLI in an isolated
+working directory, tracks the job, and re-enters the conversation with the
+result when it finishes.
+
+
+## The `coding:` block
+
+Declare an adapter once at the top level. With no `coding:` block, nothing is
+constructed and no tool is registered.
+
+```yaml
+coding:
+  client: droid                 # a bundled adapter template
+  model: claude-sonnet-4-5      # opaque; per-call override allowed
+  workdirs:
+    - ./workspaces               # each job runs in <root>/<user_id>/<request_id>
+  cleanup: delete                # delete (default, TTL sweep for strays) | keep
+  timeout: 30m
+  max_concurrent: 3              # per user
+  env:                           # the ONLY place ${{ secrets.* }} resolves
+    ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}"
+```
+
+Instead of `client`, you can inline an adapter with a `command`, structured
+`args` fragments containing `{prompt}`, `{id}`, and `{model}` slots, an
+`output` mode (`stream-json`, `json`, or `text`), and optional `parse.result`
+and `parse.session_id` selectors. A resource-side `groups:` allowlist,
+`extra_args` vendor passthrough, and per-call `model` override are supported.
+Named templates own their adapter shape, so do not combine `client` with the
+inline keys `command`, `args`, `output`, or `parse`.
+
+Load-time validation is fail-fast: binary presence, adapter schema, workdir
+roots, group existence (when RBAC is active), and the output/cleanup/timeout
+enums. `${{ secrets.* }}` referenced anywhere outside `env:` fails the load.
+
+### Bundled adapters
+
+| Adapter | Notes |
+|---------|-------|
+| `claude-code` | Session via fresh id (create-or-resume) |
+| `droid` | `--session-id` + `--output-format json` |
+| `opencode` | `opencode run --format json`; captured session id |
+| `pi` | `pi --print --mode json`; captured session id |
+
+Templates are formation-local shadowable, with an inline escape hatch.
+
+
+## The `delegate_coding` tool
+
+When a `coding:` block exists, agents get a `delegate_coding` built-in tool. It
+is **always asynchronous**: it returns a job id immediately.
+
+Parameters: `prompt`, `workdir`, `model`, and `continue_job_id` (session
+continuation - vendor session ids persist on the job record and never reach
+agents). Allowlist, concurrency, and unknown-job rejections come back as
+friendly error dicts, never a crashed turn.
+
+
+## Managing jobs
+
+Delegations are tracked background jobs, visible via the scheduler `/jobs`
+surface (list, cancel, logs). Cancelling kills the process group but keeps the
+session resumable. Completion re-enters the conversation through the middleware
++ RBAC pipeline (`route_class: delegation`) and is delivered via the
+[proactiveness](proactiveness.md) notification router.
+
+
+## Learn More
+
+- [Tools & MCP](tools-and-mcp.md) - other built-in tools
+- [Access Control](access-control.md) - the `groups:` allowlist and re-entry pipeline
+- [Async Processing](async.md) - background jobs and re-entry

--- a/docs/concepts/knowledge-and-rag.md
+++ b/docs/concepts/knowledge-and-rag.md
@@ -57,6 +57,25 @@ MUXI uses [MarkItDown](https://github.com/microsoft/markitdown) for document con
 - Files are chunked and cached with MD5; unchanged files are skipped on restart, only deltas are re-embedded.
 
 
+## Reasoning RAG (tree retrieval)
+
+Vector chunking works well for short passages but loses the structure of long
+documents. For large files, MUXI can index a document as a **hierarchical tree**
+and reason over it at query time instead of matching isolated chunks. A per-file
+gate (`knowledge.reasoning_threshold`) decides automatically; a per-source
+`retrieval:` override forces the mode:
+
+- **`tree` (Method A)** - an LLM navigates the compressed tree and selects the
+  relevant nodes. No embeddings, best structural understanding.
+- **`tree-vector` (Method B)** - per-node chunk embeddings scored with the
+  PageIndex formula. No per-query LLM calls, cheaper than Method A.
+- **`hybrid`** - both run in parallel and a sufficiency evaluator decides whether
+  to fetch more, trading cost for recall.
+
+Every mode falls back to plain vector search on failure, so a tree never breaks a
+turn. See the [knowledge reference](../reference/knowledge.md#retrieval-modes-reasoning-rag)
+for the `knowledge.tree` settings and per-source configuration.
+
 ## Multimodal Support
 
 MUXI understands images, not just extracts text from them:

--- a/docs/concepts/llm-providers.md
+++ b/docs/concepts/llm-providers.md
@@ -79,6 +79,50 @@ llm_models:
   - text: "http://llama.example.com/v1/llama-3-70b-instruct"
 ```
 
+## Hierarchical model selection
+
+Model choice follows the formation hierarchy with **lowest-level-wins**
+overrides. Authors specify a model where the knowledge lives; there is no
+capability inference.
+
+```
+formation llm.models  →  agent llm_models  →  SOP/trigger/skill frontmatter model:  →  per-step [model:x]
+        (broadest)                                                                        (most specific)
+```
+
+Every model reference in `sops/`, `triggers/`, and `skills/` is validated at
+load time (fail-fast). At request time, model selection never crashes a turn: an
+unresolvable override falls back to the agent default, and a failing override
+call retries on the agent's own model.
+
+### Aliases
+
+`llm.aliases` maps semantic names to `provider/model`, resolved before cache
+keying so an alias and its target share one cached instance. A broken alias
+errors both at its definition and at every usage site.
+
+```yaml
+# formation.yaml
+llm:
+  models:
+    - text: "openai/gpt-4o-mini"
+  aliases:
+    fast: "openai/gpt-4o-mini"
+    premium: "anthropic/claude-opus-4.5"
+```
+
+```markdown
+<!-- sops/deep-analysis.md frontmatter -->
+---
+model: premium
+---
+```
+
+> [!NOTE]
+> Formations without `llm.aliases` or frontmatter `model:` fields behave exactly
+> as before. When the same underlying model appears under several capabilities,
+> overrides deterministically prefer the `text` capability's entry.
+
 ## Model choice matrix example
 
 - **Reasoning-heavy:** GPT-5, Claude Opus 4.5

--- a/docs/concepts/memory-system.md
+++ b/docs/concepts/memory-system.md
@@ -254,6 +254,27 @@ memory:
 - All memory is user-isolated in production
 
 
+## Beyond conversation memory
+
+The four layers above capture chat context. On top of them MUXI adds a memory
+*platform* for durable, structured, auditable knowledge:
+
+- **Scopes** - a memory is written to one scope (`user`, `group`, or
+  `formation`) and read up the chain, so shared knowledge is separate from
+  personal recall. Shared writes are [grant-gated](access-control.md#shared-memory-grants).
+- **Ingestion** - developers and pipelines push content through `POST /v1/memories`
+  (idempotent by `(source, source_id)`), not just conversation.
+- **Event substrate** - every write is an immutable event; the stores are
+  rebuildable projections. This powers provenance ("why do you think X?"),
+  `POST /v1/memory/rebuild`, decay, and GDPR `POST /v1/memory/forget`.
+- **Knowledge graph & Captain's Log** - structured entity/relationship
+  extraction with contradiction handling, a temporal per-user narrative digest
+  (via `/history`), and a lessons loop that feeds agent prompts.
+
+See the [memory reference](../reference/memory.md#memory-scopes) for the full
+config and API surface.
+
+
 ## Learn More
 
 - [Configure Memory](../reference/memory.md) - YAML syntax

--- a/docs/concepts/proactiveness.md
+++ b/docs/concepts/proactiveness.md
@@ -1,0 +1,133 @@
+---
+title: Proactiveness
+description: Let a formation initiate contact - notifications, heartbeats, channels, and slash commands
+---
+
+# Proactiveness
+
+## Formations that reach out, not just respond
+
+By default a formation only answers when spoken to. The `proactive:` block lets
+it initiate contact: deliver notifications, run periodic heartbeats, and address
+users on the channel they last used. Everything here is inert until configured.
+
+
+## Channels are transformers
+
+A **channel** is a named reference to a [trigger transformer](../reference/triggers.md),
+so outbound delivery reuses the same template substitution, auth, and retry
+machinery, with a single webhook fallback when every channel fails.
+
+Bundled dormant templates ship for `slack`, `telegram`, `discord`, and `email`
+(real platform payload shapes, no URLs, inert until referenced, shadowed by a
+formation-local `transformers/` file). Email emits a constructed message object
+(from/to/subject/body/headers) to your bridge webhook; SMTP/SES wiring stays
+your side.
+
+Each channel accepts only two keys: `transformer` (required) and an optional
+`url` (an http(s) URL or a `${{ secrets.* }}` template) that overrides the
+transformer's own endpoint.
+
+```yaml
+proactive:
+  channels:
+    slack:
+      transformer: slack
+      url: "${{ secrets.SLACK_WEBHOOK }}"
+  default_channel: slack        # a channel name or "webhook"
+```
+
+
+## Routing precedence
+
+Outbound delivery resolves in this order: explicit channel(s) → user preference
+→ formation default (`default_channel`) → webhook. The reserved targets `last`,
+`preferred`, and `webhook` and multi-channel arrays are supported. Per-user channel state
+(preferred channel, addressing context, last channel, timezone) is kept in
+memory with write-through persistence and exposed via:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /v1/notifications` | Send a notification through the routing chain |
+| `GET /v1/users/{id}/channels` | Read a user's channel state |
+| `PUT /v1/users/{id}/channels` | Update a user's channel state |
+
+Inbound chat and triggers record which channel a user last spoke on, so "reply
+where they are" works.
+
+
+## Heartbeat
+
+A heartbeat rides the existing scheduler through a periodic-task extension point:
+interval gating, active hours (fixed or user-timezone, overnight ranges, weekend
+flags), and a fresh session per run with full failure isolation.
+
+```yaml
+proactive:
+  heartbeat:
+    enabled: true                # default true when the block is present
+    interval: "30m"              # <N>s / <N>m / <N>h (optional "every " prefix)
+    target: "last"               # last | preferred | webhook | <channel>
+    active_hours:                # optional; absent means always active
+      start: "08:00"
+      end: "20:00"
+      timezone: "user"           # IANA name, or "user" for per-user tz
+      weekends: true             # false suppresses Saturday/Sunday
+    instruction: "..."           # optional extra prompt content
+    sop: my-heartbeat            # optional SOP name for the base prompt
+```
+
+A heartbeat enabled with no `sop:` / `instruction:` falls back to a bundled
+default SOP (check due jobs and recent context, reach out only when warranted,
+otherwise emit `HEARTBEAT_OK`). The `HEARTBEAT_OK` sentinel suppresses delivery
+and is detected even when synthesis layers wrap it - scoped to heartbeat
+sessions, so a normal chat that mentions it is untouched.
+
+
+## Soul documents
+
+The overlord's persona can live in a `SOUL.md` / `soul.md` next to
+`formation.yaml`, auto-discovered as the default persona. Precedence: `SOUL.md`
+> `soul.md` > inline `overlord.soul` > built-in default. Agents stay
+single-file: an agent's character lives in its `system_message`.
+
+
+## Slash commands
+
+An opt-in `commands:` block maps `/command` to SOPs by explicit invocation (no
+LLM round-trip for unknown commands). Nine fully deterministic built-in
+commands are active whenever the block is enabled:
+
+| Command | Purpose |
+|---------|---------|
+| `/setup` | Guided per-user setup flow derived from the formation's own config |
+| `/jobs` | List/pause/resume/cancel/logs for the caller's scheduled jobs |
+| `/identity` | Link/unlink identifiers (cross-user protected) |
+| `/channels` | Read/write channel state (`/channels test` sends a real notification) |
+| `/preferences` | Read/write per-user preferences |
+| `/reset` | Clear the current session buffer |
+| `/help` | List available commands |
+| `/status` | Read formation status |
+| `/learnings` | Review, apply, or dismiss pending self-tuning lessons |
+
+Formation-defined commands shadow built-ins (author control wins), and a
+`commands.builtin:` map disables individual built-ins.
+
+```yaml
+commands:
+  enabled: true
+  aliases:
+    tasks: jobs
+  builtin:
+    reset: false
+```
+
+The feature is inert when `commands:` is absent. With the block present,
+`enabled` defaults to `true`.
+
+
+## Learn More
+
+- [Scheduled Tasks](scheduled-tasks.md) - the scheduler heartbeats ride on
+- [Triggers & Webhooks](triggers-and-webhooks.md) - transformers power channels
+- [Overlord Soul](soul.md) - the persona a SOUL.md document defines

--- a/docs/concepts/self-tuning.md
+++ b/docs/concepts/self-tuning.md
@@ -1,0 +1,139 @@
+---
+title: Self-Tuning
+description: How a formation learns from its own activity and improves over time
+---
+
+# Self-Tuning
+
+## Formations that learn from how they're used
+
+A MUXI formation observes its own activity and periodically distills what it
+learns into durable behavioral guidance. That guidance lives in a file called
+`MUXI.md` at the formation root - the formation's "captain's log" of learned
+behavior - and it steers the overlord and agents on every subsequent turn.
+
+Self-tuning is **on by default**. Every formation improves out of the box; you
+can dial it down or turn it off with the `tuning:` block.
+
+
+## How the loop works
+
+A single in-runtime job runs on a schedule (once a day by default) and makes two
+passes:
+
+1. **Digest** - it reads the event spool accumulated since the last checkpoint
+   and aggregates it into a compact activity report, then checkpoints. The
+   digest is also stored as a formation-scope Captain's Log entry and injected
+   into every user's context as the "Formation operations log."
+2. **Tune** - it reads that digest, recent log entries, and past experiments,
+   detects patterns, and distills behavioral learnings into a candidate revision
+   of `MUXI.md`. Learnings whose watched metric never moved are retired. A short
+   "morning report" summarizes what changed.
+
+Depending on `auto_apply`, a candidate revision is either applied directly to
+`MUXI.md` or written alongside it as `PENDING-MUXI.md` for you to review.
+
+
+## Configuration
+
+The top-level `tuning:` block controls the loop. An absent block means "on with
+defaults":
+
+```yaml
+tuning:
+  active: true            # Off switch: false disables the loop entirely
+  interval_hours: 24      # How often the loop runs (default: 24)
+  auto_apply: true        # Apply revisions directly, or hold them as pending
+```
+
+Shorthands:
+
+```yaml
+tuning: false             # Same as { active: false }
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `active` | `true` | Whether the tuning loop runs at all |
+| `interval_hours` | `24` | Hours between loop passes (must be positive) |
+| `auto_apply` | `true` | `true` applies revisions to `MUXI.md`; `false` writes `PENDING-MUXI.md` for review |
+
+Invalid values fail fast at formation load, never at tuning time.
+
+
+## The tuning files
+
+| File | Role |
+|------|------|
+| `MUXI.md` | The live, applied learnings - read on every turn |
+| `PENDING-MUXI.md` | A candidate revision awaiting your review (only when `auto_apply: false`) |
+
+Both files are **runtime-owned state**. When you redeploy or roll back a
+formation, the server preserves the live `MUXI.md` and `PENDING-MUXI.md` (just
+like `memory.db`) so an update never wipes what the formation has learned. See
+[Managing Formations](../server/managing-formations.md#preserved-runtime-state).
+
+
+## Reviewing suggestions from the CLI
+
+When `auto_apply` is off, the CLI lets you inspect and act on the pending
+suggestion:
+
+```bash
+# Review the live and pending state
+muxi tuning show        # Display the live MUXI.md
+muxi tuning pending     # Display the pending suggestion, if any
+
+# Act on the pending suggestion
+muxi tuning apply       # Promote the pending suggestion to the live MUXI.md
+muxi tuning dismiss     # Discard it (dismissed learnings are never re-proposed)
+```
+
+The morning report can also carry an apply/dismiss widget, so a review can
+happen inline in a chat channel as well as from the CLI.
+
+When the `commands:` block is enabled, the deterministic `/learnings` command
+provides the same chat surface:
+
+```text
+/learnings
+/learnings pending
+/learnings apply
+/learnings dismiss
+```
+
+`apply` and `dismiss` are refused in multi-user mode because they change
+formation-wide guidance; operators must use the admin tuning API instead.
+
+
+## API surface
+
+The same state is available over the admin API (all paths under `/v1`, admin
+key required):
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /v1/tuning` | Read the live `MUXI.md` |
+| `POST /v1/tuning` | Replace the live file (human upload) |
+| `POST /v1/tuning/run` | Trigger one tuning loop pass |
+| `GET /v1/tuning/pending` | Read the pending suggestion (null when none) |
+| `PATCH /v1/tuning/pending` | Accept: promote pending to live |
+| `DELETE /v1/tuning/pending` | Dismiss: discard the suggestion |
+
+Applied learnings are injected into the overlord's context via the captain's-log
+layer, so guidance steers every turn without re-reading the whole file.
+
+
+## Benchmark-driven observation
+
+When `MUXI_BENCH_ROOT` is set, the tuning loop also observes benchmark runs
+rooted there, folding their outcomes into the digest so learnings can be
+correlated against reproducible benchmark metrics rather than live traffic
+alone.
+
+
+## Learn More
+
+- [Managing Formations](../server/managing-formations.md) - how tuning state survives updates
+- [Formation Schema](../reference/formation-schema.md) - the full configuration surface
+- [Observability](observability.md) - the event spool the digest reads from

--- a/docs/concepts/tools-and-mcp.md
+++ b/docs/concepts/tools-and-mcp.md
@@ -114,7 +114,7 @@ MUXI:
 - Dozens of tools without burning context window
 
 
-## Tool Filtering (whitelist / blacklist)
+## Tool Filtering (`allow` / `deny`)
 
 Semantic indexing already trims context contamination per request, but for very large MCP catalogs (30+ tools — Microsoft 365, Google Workspace, large internal MCP servers) you also want to trim the *full* tool surface advertised at the protocol level. Otherwise the agent's allowed-tool list, the planning prompt, and the registry grow with every irrelevant tool the upstream MCP exposes.
 
@@ -132,7 +132,7 @@ auth:
   ACCESS_TOKEN: "${{ user.credentials.MS365 }}"
 
 tools:
-  whitelist:
+  allow:
     - "list-excel-files"
     - "read-excel-*"
     - "update-excel-*"
@@ -143,7 +143,7 @@ Or, the inverse — keep most tools but block destructive ones:
 ```yaml
 # mcp/internal-db.afs - block every destructive operation
 tools:
-  blacklist:
+  deny:
     - "drop-*"
     - "delete-*"
     - "truncate-*"
@@ -154,7 +154,7 @@ tools:
 ```
 Upstream MCP tools/list response
         ↓
-   Filter (whitelist OR blacklist, fnmatch-style globs)
+   Filter (allow, then deny; fnmatch-style globs)
         ↓
 Agent-visible tool registry (this is what the LLM ever sees)
 ```
@@ -165,11 +165,12 @@ The filter runs at MCP registration and on every `tools/list` refresh. Filtered-
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `tools.whitelist` | string[] | If set, **only** these tool names are exposed. fnmatch globs (`*`, `?`) supported. |
-| `tools.blacklist` | string[] | If set, every tool **except** these is exposed. Same glob syntax. |
+| `tools.allow` | string[] | If set, **only** these tool names are exposed. fnmatch globs (`*`, `?`) supported. |
+| `tools.deny` | string[] | These tool names are excluded after `allow` is applied. Same glob syntax. |
 
-> [!IMPORTANT]
-> `whitelist` and `blacklist` are mutually exclusive. Setting both fails formation validation at load time, by design — there is no useful interpretation of "include only A, but also exclude B".
+> [!NOTE]
+> `whitelist` and `blacklist` remain accepted aliases. `allow` and `deny` are
+> canonical and may be combined; deny is applied after allow.
 
 ### When to use it
 

--- a/docs/deep-dives/idempotency.md
+++ b/docs/deep-dives/idempotency.md
@@ -1,0 +1,90 @@
+---
+title: Idempotency
+description: Safe retries for mutating Formation API requests
+---
+
+# Idempotency
+
+## Retry a mutating request without doing the work twice
+
+Network calls fail halfway. A client that retries a "send chat", "fire trigger",
+or "create scheduled job" request has no way to know whether the first attempt
+took effect. Idempotency keys close that gap: a retry carrying the same key
+replays the original response instead of running the request again.
+
+
+## The header
+
+Clients send an `X-Muxi-Idempotency-Key` header on mutating requests. All MUXI
+SDKs generate one automatically (set once per logical request, reused across the
+SDK's own retries), so idempotency is on by default when you use an SDK. When
+calling the API directly, supply your own unique value per logical operation:
+
+```bash
+curl -X POST http://localhost:7890/api/my-assistant/v1/chat \
+  -H "X-Muxi-Client-Key: $CLIENT_KEY" \
+  -H "X-Muxi-User-Id: user-123" \
+  -H "X-Muxi-Idempotency-Key: 7b2f9c1e-3a44-4c8d-9f21-1e6b0d8a55aa" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Charge my account and summarize the invoice"}'
+```
+
+
+## Where it applies
+
+The runtime honours idempotency keys on these mutating Formation API endpoints:
+
+| Endpoint | Method |
+|----------|--------|
+| Chat (`/v1/chat`) | POST |
+| Execute trigger (`/v1/triggers/{trigger_name}`) | POST |
+| Create scheduled job (`/v1/scheduler/jobs`) | POST |
+
+Requests without the header run unchanged - the feature is entirely opt-in per
+request.
+
+
+## Semantics
+
+- **Only successful (2xx) JSON responses are cached.** Errors are always
+  retryable, so a failed attempt never poisons the key.
+- **Streaming (SSE) responses pass through untouched.** A token stream can't be
+  replayed from a response cache. A repeated streaming request executes again,
+  so use `stream: false` when you need idempotent chat retries.
+- **Concurrent requests with the same key are single-flighted.** The second
+  caller waits for the first to finish, then receives the same cached response
+  rather than racing it.
+- **Keys are scoped per method, path, and user.** Different callers, endpoints,
+  or path parameters (e.g. two different trigger names) can reuse the same key
+  value safely.
+- **Storage is in-process with a 24-hour TTL.** Like async request state, cached
+  responses do not survive a runtime restart.
+
+
+## The echoed key
+
+When a request carries an idempotency key, the runtime echoes it back on the
+response envelope under `request.idempotency_key`:
+
+```json
+{
+  "object": "chat_response",
+  "request": {
+    "id": "req_abc123",
+    "idempotency_key": "7b2f9c1e-3a44-4c8d-9f21-1e6b0d8a55aa"
+  },
+  "success": true,
+  "data": { }
+}
+```
+
+All SDKs surface this echoed value on the unwrapped response (Go exposes it via
+`RequestInfo.IdempotencyKey`; the others carry `idempotency_key` on the
+unwrapped result), so a client can confirm which key a response belongs to.
+
+
+## Learn More
+
+- [API Reference](../reference/api-reference.md) - request headers and envelope
+- [Resilience](resilience.md) - retries, timeouts, and graceful degradation
+- [Request Lifecycle](request-lifecycle.md) - how a request flows through the runtime

--- a/docs/deep-dives/real-time-streaming.md
+++ b/docs/deep-dives/real-time-streaming.md
@@ -129,8 +129,33 @@ while (true) {
 | `chunk` | Text generated | `{"text": "...", "agent": "..."}` |
 | `tool_start` | Tool invoked | `{"tool": "...", "args": {...}}` |
 | `tool_end` | Tool completed | `{"tool": "...", "result": "..."}` |
+| `ui` | End-of-turn, when the response carries UI widgets | `{"ui": [ ... ]}` |
 | `error` | Error occurred | `{"error": "...", "code": "..."}` |
 | `done` | Stream complete | `{"session_id": "..."}` |
+
+
+## UI Events
+
+When a response carries UI widgets (choices to pick, an external link, or an MCP
+UI resource), they ride a single `ui` event emitted at end-of-turn, just before
+`done`:
+
+```
+event: chunk
+data: {"text": "Which region should I use?"}
+
+event: ui
+data: {"ui": [{"type": "options", "id": "ui_a1b2c3", "prompt": "Which region?", "options": [{"value": "us", "label": "United States"}, {"value": "eu", "label": "Europe"}]}]}
+
+event: done
+data: {"finished": true}
+```
+
+A turn with no widgets omits the `ui` event entirely, so the stream is
+byte-identical to before. Clients should ignore widget types they don't
+understand - the response text always carries the fallback. See
+[Response UI Widgets](../reference/response-ui-widgets.md) for the widget types,
+fields, and how to reply to an `options` widget.
 
 
 ## Tool Events

--- a/docs/guides/add-mcp-tools.md
+++ b/docs/guides/add-mcp-tools.md
@@ -221,7 +221,7 @@ auth:
 ```
 
 
-## Filter the Tool Surface (whitelist/blacklist)
+## Filter the Tool Surface (`allow` / `deny`)
 
 If you're integrating an MCP server that exposes a very large catalog (Microsoft 365, Google Workspace, ms365-assistant, big internal MCP servers) — say, 30+ tools — the agent's planning quality degrades and its prompt grows even though it only ever needs a handful. Filter at the protocol level so the LLM only ever sees the slice you actually want:
 
@@ -237,18 +237,18 @@ auth:
   ACCESS_TOKEN: "${{ user.credentials.MS365 }}"
 
 tools:
-  whitelist:
+  allow:
     - "list-excel-files"
     - "read-excel-*"
     - "update-excel-*"
 ```
 
-Or, blacklist the dangerous verbs everywhere instead:
+Or, deny the dangerous verbs everywhere instead:
 
 ```yaml
 # mcp/internal-db.afs
 tools:
-  blacklist:
+  deny:
     - "drop-*"
     - "delete-*"
     - "truncate-*"
@@ -256,16 +256,17 @@ tools:
 
 | Field | Behavior |
 |-------|----------|
-| `tools.whitelist` | Only listed tool names are exposed. fnmatch globs (`*`, `?`) supported. |
-| `tools.blacklist` | Every tool except listed names is exposed. Same glob syntax. |
+| `tools.allow` | Only listed tool names are exposed. fnmatch globs (`*`, `?`) supported. |
+| `tools.deny` | Listed tool names are excluded after `allow` is applied. Same glob syntax. |
 
-> [!IMPORTANT]
-> `whitelist` and `blacklist` are mutually exclusive — setting both fails formation validation. Pick the one that's shorter to maintain.
+> [!NOTE]
+> `whitelist` and `blacklist` remain accepted aliases. `allow` and `deny` are
+> canonical and may be combined; deny is applied after allow.
 
 > [!TIP]
-> For catalogs this large, also consider splitting the upstream MCP into per-domain `.afs` files (one for excel, one for email, one for calendar, etc.), each with its own whitelist, and assigning each one to a domain-specialist agent. See [Per-agent MCP scoping](../guides/build-multi-agent-systems.md#per-agent-mcp-scoping-for-large-catalogs) for the full pattern.
+> For catalogs this large, also consider splitting the upstream MCP into per-domain `.afs` files (one for excel, one for email, one for calendar, etc.), each with its own allow list, and assigning each one to a domain-specialist agent. See [Per-agent MCP scoping](../guides/build-multi-agent-systems.md#per-agent-mcp-scoping-for-large-catalogs) for the full pattern.
 
-Full schema details: [Tools Reference → Tool Filtering](../reference/tools.md#tool-filtering-whitelist--blacklist).
+Full schema details: [Tools Reference → Tool Filtering](../reference/tools.md#tool-filtering-allow--deny).
 
 
 ## Agent-Specific Tools

--- a/docs/guides/build-custom-ui.md
+++ b/docs/guides/build-custom-ui.md
@@ -230,6 +230,63 @@ history = formation.get_session_messages("sess_abc123", "user-123")
 [[/tabs]]
 
 
+## Rendering UI Widgets
+
+A response can carry optional **UI widgets** - a set of choices to pick from, a
+link to send the user somewhere, or an MCP UI resource. They arrive on streaming
+chat as a dedicated `ui` event just before the stream completes. Rendering them
+natively is optional: the response text always works on its own, so a client that
+ignores widgets still behaves correctly.
+
+[[tabs]]
+
+[[tab TypeScript]]
+```typescript
+for await (const chunk of formation.chatStream({ message }, userId)) {
+  if (chunk.type === 'ui') {
+    for (const widget of chunk.ui) {
+      if (widget.type === 'options') {
+        renderChoiceButtons(widget.prompt, widget.options, (value) => {
+          // Reply with the picked value; the text stands alone too.
+          formation.chat({ message: value, ui_response: { id: widget.id, value } }, userId);
+        });
+      } else if (widget.type === 'action_link') {
+        renderLink(widget.label, widget.url);
+      }
+      // Ignore unknown widget types (progressive enhancement).
+    }
+  } else {
+    appendText(chunk.text || '');
+  }
+}
+```
+[[/tab]]
+
+[[tab Python]]
+```python
+from muxi import parse_ui_widgets
+
+for chunk in formation.chat_stream({"message": message}, user_id=user_id):
+    widgets = parse_ui_widgets(chunk)
+    if widgets:
+        for widget in widgets:
+            if widget["type"] == "options":
+                choice = prompt_user(widget["prompt"], widget["options"])
+                formation.chat(
+                    {"message": choice, "ui_response": {"id": widget["id"], "value": choice}},
+                    user_id=user_id,
+                )
+    else:
+        print(chunk.text, end="", flush=True)
+```
+[[/tab]]
+
+[[/tabs]]
+
+See [Response UI Widgets](../reference/response-ui-widgets.md) for every widget
+type, its fields, and the reply path.
+
+
 ## API Reference
 
 For direct API access (without SDK), see the endpoint reference:
@@ -246,6 +303,12 @@ For direct API access (without SDK), see the endpoint reference:
 - `X-Muxi-User-Id` - User identifier
 - `Content-Type: application/json`
 - `Accept: text/event-stream` (for streaming)
+
+**Optional headers:**
+- `X-Muxi-Idempotency-Key` - Unique per logical request so a successful
+  non-streaming mutation can be retried without re-running it. Streams and
+  failures are not replayed. The SDKs set this automatically; see
+  [Idempotency](../deep-dives/idempotency.md).
 
 [Full API Documentation →](../reference/api-reference.md)
 

--- a/docs/guides/build-multi-agent-systems.md
+++ b/docs/guides/build-multi-agent-systems.md
@@ -137,7 +137,7 @@ When you're integrating an MCP server with a very large tool surface — Microso
 
 **Why:**
 - The Overlord routes by tool capability. If every Excel question and every email question lands on the same agent, the routing signal is gone.
-- The planning prompt for an agent grows with its tool surface. A whitelisted slice keeps the prompt small and improves tool-selection accuracy.
+- The planning prompt for an agent grows with its tool surface. An allowed slice keeps the prompt small and improves tool-selection accuracy.
 - Per-domain agents can have per-domain system messages tailored to the domain's idioms.
 
 **Worked example** — splitting Microsoft 365 across four specialist agents:
@@ -153,7 +153,7 @@ auth:
   type: env
   ACCESS_TOKEN: "${{ user.credentials.MS365 }}"
 tools:
-  whitelist:
+  allow:
     - "list-excel-files"
     - "read-excel-*"
     - "update-excel-*"
@@ -171,7 +171,7 @@ auth:
   type: env
   ACCESS_TOKEN: "${{ user.credentials.MS365 }}"
 tools:
-  whitelist:
+  allow:
     - "list-mail-*"
     - "read-mail-*"
     - "send-mail"
@@ -203,7 +203,7 @@ Repeat the same shape for `ms365-email-agent.afs`, `ms365-calendar-agent.afs`, `
 > [!TIP]
 > The same pattern applies to any large MCP — Google Workspace, Atlassian, Salesforce, internal company MCPs. The rule of thumb: if a single MCP server exposes more tools than a single agent's role naturally needs, split it.
 
-See [Tools & MCP → Tool Filtering](../concepts/tools-and-mcp.md#tool-filtering-whitelist--blacklist) for the underlying mechanism.
+See [Tools & MCP → Tool Filtering](../concepts/tools-and-mcp.md#tool-filtering-allow--deny) for the underlying mechanism.
 
 
 ## Step 3: Configure Orchestration

--- a/docs/reference/a2a.md
+++ b/docs/reference/a2a.md
@@ -7,10 +7,11 @@ description: Configure agent-to-agent communication with external services
 
 ## Connect to external agent services
 
-A2A (Agent-to-Agent) services let your formation communicate with external agent systems. Define connections to remote services that your agents can delegate tasks to.
+A2A (Agent-to-Agent) services let a formation communicate with external agent
+systems. Put reusable service definitions in `a2a/*.afs`; configure inbound
+server auth and extended outbound auth in the top-level `a2a:` block.
 
-
-## Your First A2A Service
+## Service files
 
 Create `a2a/analytics.afs`:
 
@@ -18,51 +19,68 @@ Create `a2a/analytics.afs`:
 schema: "1.0.0"
 id: analytics-engine
 name: Analytics Engine
-description: External analytics service for data processing
+description: External analytics service
+url: "https://analytics.company.com"
+active: true
+timeout_seconds: 30
+retry_attempts: 3
 
-endpoint: "https://analytics.company.com"
 auth:
   type: bearer
   token: "${{ secrets.ANALYTICS_TOKEN }}"
 ```
 
-## Configuration Fields
+Required fields are `schema`, `id`, `name`, `description`, and an HTTP(S)
+`url`. Optional top-level fields include `active`, `timeout_seconds`,
+`retry_attempts`, `author`, `version`, `documentation`, and `support_contact`.
+Service-file auth supports `none`, `api_key`, `bearer`, `basic`, and `custom`.
 
-### Required Fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `schema` | string | Schema version (`"1.0.0"`) |
-| `id` | string | Unique identifier |
-| `description` | string | Service capabilities |
-| `endpoint` | string | Service endpoint URL |
-
-### Connection Settings
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `name` | string | - | Human-readable name |
-| `protocol` | enum | `https` | `http`, `https`, or `grpc` |
-| `version` | string | - | Service API version |
-| `timeout_seconds` | int | `30` | Request timeout |
-
-### Retry Configuration
+## Top-level configuration
 
 ```yaml
-retry_attempts: 3
-retry_delay_seconds: 1
-retry_backoff_multiplier: 2.0
+# formation.yaml
+a2a:
+  enabled: true
+  inbound:
+    enabled: true
+    host: 0.0.0.0
+    port: 8181
+    auth:
+      type: hmac
+      secret: "${{ secrets.A2A_HMAC_SECRET }}"
+      timestamp_tolerance: 300
+  outbound:
+    enabled: true
+    default_timeout_seconds: 30
+    default_retry_attempts: 3
+    services:
+      - id: analytics
+        url: "https://analytics.example.com"
+        auth:
+          type: oauth2
+          client_id: "analytics-client"
+          client_secret: "${{ secrets.OAUTH_SECRET }}"
+          token_url: "https://auth.example.com/oauth/token"
+          scope: "read write"
 ```
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `retry_attempts` | int | `3` | Number of retries (0-10) |
-| `retry_delay_seconds` | int | `1` | Initial delay between retries |
-| `retry_backoff_multiplier` | float | `2.0` | Exponential backoff multiplier |
+`id` is the canonical identifier for credential registration. The runtime
+matches outbound requests through the service's `url`; when several URL paths
+match, the most specific path wins. The legacy `service_id` field remains
+accepted for compatibility but is deprecated.
 
 ## Authentication
 
-### Bearer Token
+### API key
+
+```yaml
+auth:
+  type: api_key
+  header: X-API-Key
+  key: "${{ secrets.SERVICE_API_KEY }}"
+```
+
+### Bearer token
 
 ```yaml
 auth:
@@ -70,7 +88,7 @@ auth:
   token: "${{ secrets.SERVICE_TOKEN }}"
 ```
 
-### Basic Auth
+### Basic auth
 
 ```yaml
 auth:
@@ -79,154 +97,80 @@ auth:
   password: "${{ secrets.SERVICE_PASSWORD }}"
 ```
 
-### API Key
+### Custom headers
 
 ```yaml
 auth:
-  type: api_key
-  header: "X-API-Key"
-  key: "${{ secrets.SERVICE_API_KEY }}"
+  type: custom
+  headers:
+    X-Tenant: acme
+    X-Service-Key: "${{ secrets.SERVICE_KEY }}"
 ```
 
-### OAuth2
+### OAuth2 client credentials (outbound only)
 
 ```yaml
-auth:
-  type: oauth2
-  oauth2:
-    client_id: "your-client-id"
-    client_secret: "${{ secrets.OAUTH_SECRET }}"
-    token_url: "https://auth.example.com/oauth/token"
-    scopes: ["read", "write"]
+a2a:
+  outbound:
+    services:
+      - id: analytics
+        url: "https://analytics.example.com"
+        auth:
+          type: oauth2
+          client_id: "your-client-id"
+          client_secret: "${{ secrets.OAUTH_SECRET }}"
+          token_url: "https://auth.example.com/oauth/token"
+          scope: "read write"
 ```
 
-## Health Checks
+Tokens are cached until expiry. `scope` is an optional space-delimited string.
 
-Monitor service availability:
+### HMAC (inbound and outbound)
+
+HMAC uses SHA-256 over the timestamp. Inbound verification uses constant-time
+comparison, rejects stale timestamps, and prevents replay. Defaults are
+`X-Signature`, `X-Timestamp`, and a 300-second inbound tolerance.
 
 ```yaml
-health_check:
-  enabled: true
-  endpoint: "/health"
-  interval_seconds: 60
-  timeout_seconds: 5
-  unhealthy_threshold: 3   # Failures before marking unhealthy
-  healthy_threshold: 2     # Successes before marking healthy
+a2a:
+  inbound:
+    enabled: true
+    auth:
+      type: hmac
+      secret: "${{ secrets.HMAC_SECRET }}"
+      timestamp_tolerance: 300
+  outbound:
+    services:
+      - id: analytics
+        url: "https://analytics.example.com"
+        auth:
+          type: hmac
+          secret: "${{ secrets.HMAC_SECRET }}"
+          signature_header: X-Signature
+          timestamp_header: X-Timestamp
 ```
 
-## Circuit Breaker
+### OpenID Connect (inbound only)
 
-Prevent cascade failures:
+OpenID verifies bearer JWTs against the issuer's JWKS and identifies callers as
+`openid:<sub>`. When `jwks_url` is omitted, the runtime uses
+`<issuer>/.well-known/jwks.json`.
 
 ```yaml
-circuit_breaker:
-  enabled: true
-  failure_threshold: 5     # Failures before opening circuit
-  success_threshold: 2     # Successes before closing circuit
-  timeout_seconds: 60      # Time in open state before retry
+a2a:
+  inbound:
+    enabled: true
+    auth:
+      type: openid
+      issuer: "https://auth.example.com"
+      audience: "your-client-id"
+      jwks_url: "https://auth.example.com/.well-known/jwks.json"
+      allowed_algorithms: ["RS256"]
+      clock_skew_seconds: 30
 ```
 
-## Rate Limiting
-
-Control request rates:
-
-```yaml
-rate_limiting:
-  requests_per_second: 10
-  requests_per_minute: 100
-  requests_per_hour: 1000
-  requests_per_day: 10000
-  burst_limit: 20
-  strategy: "sliding_window"  # sliding_window, fixed_window, token_bucket
-```
-
-## Capabilities
-
-Describe what the service offers:
-
-```yaml
-capabilities:
-  agents: ["analytics-agent", "reporting-agent"]
-  features: ["data-analysis", "visualization"]
-  streaming: true
-  async: true
-  webhooks: true
-```
-
-## Service Discovery
-
-Routing and load balancing:
-
-```yaml
-discovery:
-  registry_url: "https://registry.example.com"
-  tags: ["analytics", "data", "reporting"]
-  priority: 10      # Higher = higher priority
-  weight: 100       # 0-100 for load balancing
-```
-
-## Metadata
-
-Additional service information:
-
-```yaml
-metadata:
-  owner: "Data Team"
-  contact: "data-team@company.com"
-  documentation: "https://docs.analytics.company.com"
-  environment: "production"  # development, staging, production
-  sla:
-    uptime_percentage: 99.9
-    response_time_ms: 500
-```
-
-## Full Example
-
-```yaml
-# a2a/analytics-engine.afs
-schema: "1.0.0"
-id: analytics-engine
-name: Analytics Engine
-description: External analytics for data processing and visualization
-
-endpoint: "https://analytics.company.com"
-protocol: https
-version: "2.1.0"
-timeout_seconds: 60
-
-auth:
-  type: bearer
-  token: "${{ secrets.ANALYTICS_TOKEN }}"
-
-retry_attempts: 3
-retry_delay_seconds: 1
-retry_backoff_multiplier: 2.0
-
-health_check:
-  enabled: true
-  endpoint: "/health"
-  interval_seconds: 60
-
-circuit_breaker:
-  enabled: true
-  failure_threshold: 5
-  timeout_seconds: 60
-
-rate_limiting:
-  requests_per_minute: 100
-  burst_limit: 20
-
-capabilities:
-  agents: ["data-analyst", "report-generator"]
-  features: ["analysis", "visualization", "export"]
-  streaming: true
-  async: true
-
-metadata:
-  owner: "Data Team"
-  documentation: "https://docs.analytics.company.com"
-  environment: "production"
-```
+`oauth2` is outbound-only and `openid` is inbound-only. `api_key`, `bearer`,
+`basic`, `custom`, and `hmac` are valid in both directions.
 
 ## Learn More
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -236,6 +236,24 @@ curl http://localhost:8271/v1/chat \
 
 [Learn more about API keys →](/docs/server/authentication.md)
 
+### Idempotency (mutating requests)
+
+Send an `X-Muxi-Idempotency-Key` header on a mutating request (chat, execute
+trigger, create scheduled job) so a retry of a successful non-streaming request
+replays the original response instead of running the work twice. Streams and
+failed requests execute again. Cached responses echo the key under
+`request.idempotency_key`. The SDKs set it automatically.
+
+```bash
+curl http://localhost:8271/v1/chat \
+  -H "X-MUXI-CLIENT-KEY: fmc_client_key_here" \
+  -H "X-Muxi-User-ID: user-123" \
+  -H "X-Muxi-Idempotency-Key: 7b2f9c1e-3a44-4c8d-9f21-1e6b0d8a55aa" \
+  -d '{"message": "Hello!"}'
+```
+
+[Learn more about idempotency →](/docs/deep-dives/idempotency.md)
+
 ## Response Formats
 
 ### Server API Response Format
@@ -357,7 +375,18 @@ event: done
 data: {"finished": true}
 ```
 
-[Learn about streaming →](/docs/api/formation#streaming)
+When a response carries UI widgets, a single `ui` event is emitted at
+end-of-turn, just before `done`:
+
+```
+event: ui
+data: {"ui": [{"type": "options", "id": "ui_a1b2c3", "prompt": "Which region?", "options": [{"value": "us", "label": "United States"}]}]}
+
+event: done
+data: {"finished": true}
+```
+
+[Learn about streaming →](/docs/api/formation#streaming) · [Response UI Widgets →](/docs/reference/response-ui-widgets.md)
 
 ## Next Steps
 

--- a/docs/reference/formation-schema.md
+++ b/docs/reference/formation-schema.md
@@ -121,8 +121,15 @@ system_message: |
 knowledge:
   enabled: true
   sources:
-    - path: knowledge/docs/
+    - path: knowledge/docs/          # Local source
+    - url: s3://my-bucket/manuals/   # Remote source (path XOR url)
 ```
+
+Each source declares either `path` or `url`. Remote `url` schemes: `http`,
+`https`, `s3`, `gs`, `az`, `rsync`, `rsync+ssh`, `ftp`, `sftp`, `file`. Local
+sources may add an `agent_tree.regenerate` mode (`manual`, `on-source-change`,
+`on-formation-load`). See the [Knowledge reference](knowledge.md) for the full
+source surface.
 
 ### Agent Fields
 

--- a/docs/reference/knowledge.md
+++ b/docs/reference/knowledge.md
@@ -129,12 +129,159 @@ agents:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `path` | - | Path relative to formation |
+| `path` | - | Path relative to formation (local source) |
+| `url` | - | Remote source location (see below); mutually exclusive with `path` |
 | `description` | - | What this source contains |
 | `recursive` | false | Include subdirectories |
 | `allowed_extensions` | all | File types to include |
 | `file_limit` | 5 | Max files from this source |
 | `max_file_size` | 1MB | Skip files larger than this |
+
+Each source declares **either** `path` **or** `url` - not both.
+
+### Remote Sources
+
+A source can point at a remote location with `url:` instead of a local `path:`:
+
+```yaml
+knowledge:
+  enabled: true
+  sources:
+    - url: https://docs.example.com/handbook.pdf
+      description: Company handbook
+    - url: s3://my-bucket/knowledge/
+      description: Product manuals synced from S3
+```
+
+Supported URL schemes:
+
+`http`, `https`, `s3`, `gs`, `az`, `rsync`, `rsync+ssh`, `ftp`, `sftp`, `file`
+
+#### Per-protocol auth
+
+| Scheme | `auth` block |
+|--------|--------------|
+| `http(s)` | `basic` / `bearer`, plus optional `headers` |
+| `s3` | `aws` (omit keys to use boto3's default credential chain) |
+| `gs` | `gcp` with `credentials_json`, else Application Default Credentials |
+| `az` | `azure` with `connection_string` **or** `account_name` + `account_key` |
+| `rsync+ssh` / `sftp` | `ssh_key` or `basic`; host-key checking is strict (opt out per source with `accept_new_host_keys: true`) |
+| `ftp` | `basic` or URL userinfo |
+
+Optional SDKs ship as extras (`muxi-runtime[gcs]`, `[azure]`, `[sftp]`); a
+missing extra produces a config-time error naming it.
+
+#### Archive extraction
+
+A remote source that points at an archive can be unpacked into the mirror:
+
+```yaml
+sources:
+  - url: https://example.com/handbook.zip
+    description: Handbook
+    extract: true
+    extract_pattern: "*.md"        # keep only matching members
+    max_extracted_files: 1000      # decompression-bomb guard
+    max_extracted_size: 524288000  # 500MB, counted on the decompressed stream
+```
+
+Supported archives: `.zip`, `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`, `.tar.xz`.
+Extraction is path-traversal-safe, rejects symlink/hardlink/device members, and
+only updates the mirror after the whole archive extracts successfully (a corrupt
+archive degrades to the previously synced content).
+
+#### Scheduled re-sync
+
+```yaml
+sources:
+  - url: s3://my-bucket/knowledge/
+    description: Manuals
+    schedule: "@daily"             # cron, or @hourly/@daily/@weekly; @startup = startup-only
+    retry:
+      max_attempts: 3
+      initial_delay: 5
+      max_delay: 300
+      exponential_base: 2
+```
+
+Scheduled sources re-sync periodically through the shared scheduler; only
+changed/deleted files are re-embedded. Overlapping syncs are skipped, failures
+retry with exponential backoff and then fall back to the next cron fire, always
+serving stale content in the meantime. With no running scheduler, schedules
+degrade to startup-only sync with a warning.
+
+Trigger a re-sync on demand:
+
+```http
+POST /v1/agents/{agent_id}/knowledge/sync
+```
+
+(AdminKey; optional `{"source_id": ...}` body.)
+
+### Persistent Knowledge Trees (`agent_tree`)
+
+Local (`path`) sources can build a persistent per-agent knowledge tree and
+control when it regenerates:
+
+```yaml
+knowledge:
+  enabled: true
+  sources:
+    - path: knowledge/docs/
+      description: Product documentation
+      retrieval: hybrid
+      agent_tree:
+        regenerate: on-source-change
+```
+
+| `regenerate` value | Behavior |
+|--------------------|----------|
+| `manual` | Rebuild only when you ask (`muxi knowledge rebuild`) |
+| `on-source-change` | Rebuild when the source files change |
+| `on-formation-load` | Rebuild every time the formation loads |
+
+> `agent_tree` applies to local sources only. Sync a remote source locally first
+> if you need a persistent tree. It also requires an explicit `retrieval:
+> tree`, `tree-vector`, or `hybrid`; `vector` does not consult the tree.
+
+## Retrieval Modes (Reasoning RAG)
+
+Beyond classic vector chunking, large documents can be indexed as a hierarchical
+tree that an LLM navigates at query time. A per-file gate decides automatically:
+files above `knowledge.reasoning_threshold` tokens (default `40000`, `0`
+disables) are tree-indexed; everything else uses the vector pipeline. A per-source
+`retrieval:` override forces the mode.
+
+| `retrieval` | How it works |
+|-------------|--------------|
+| `vector` | Classic embedding chunk search (default for small files) |
+| `tree` | **Method A** - one LLM call selects nodes from the compressed tree; zero embeddings |
+| `tree-vector` | **Method B** - per-node chunk embeddings scored with the PageIndex formula; zero LLM calls per query |
+| `hybrid` | Method A and B run in parallel, results merge, and a sufficiency evaluator decides whether to fetch more |
+
+```yaml
+knowledge:
+  enabled: true
+  reasoning_threshold: 40000
+  tree:
+    model: premium                 # llm.aliases name or provider/model; defaults to the agent text model
+    terminator_model: fast         # sufficiency evaluator for hybrid mode
+    max_depth: 3                   # default
+    max_pages_per_node: 10         # default
+    max_tokens_per_node: 20000     # default
+    max_document_tokens: 500000    # default; larger files fall back to vector
+    max_sufficiency_rounds: 3      # default hybrid loop bound
+    max_fetched_nodes_pct: 50      # default hybrid loop bound
+  sources:
+    - path: knowledge/handbook/
+      description: Large handbook
+      retrieval: hybrid
+```
+
+All retrieval modes fall back to `vector` on failure - a tree build or navigation
+error never fails a turn. Tree and vector sources coexist in one agent's
+knowledge base; tree results carry a `node_path` breadcrumb. Formations without
+these keys behave byte-identically to the previous vector path.
 
 ## Supported Formats
 
@@ -248,11 +395,19 @@ MUXI caches embeddings to avoid re-indexing:
 - **Lazy loading** - First query triggers indexing
 - **Incremental updates** - Only re-embeds changed files
 
-Force reindex:
+Force reindex during local development:
 
 ```bash
 muxi dev --reindex
 ```
+
+Force-rebuild the persistent per-agent knowledge trees on a running formation:
+
+```bash
+muxi knowledge rebuild
+```
+
+This calls the runtime's `POST /v1/knowledge/rebuild` endpoint (admin).
 
 ## Performance Tips
 

--- a/docs/reference/memory.md
+++ b/docs/reference/memory.md
@@ -130,6 +130,11 @@ embedding_model: local/nomic-ai/nomic-embed-text-v1.5:e04b7e4c5ea3e3d7e41e13d4c0
 > [!TIP]
 > Local models are great for development and air-gapped environments. No API key needed -- the default model is pre-downloaded by `muxi-server init` into a shared cache (`$MUXI_CACHE_DIR` or `<data_dir>/cache`) and bind-mounted into formations at `/opt/hf-cache`, so deploys don't stall on a multi-hundred-MB fetch.
 
+> [!NOTE]
+> On macOS the CoreML execution provider is **off by default** for local ONNX
+> embedding models (partition negotiation cost more than it saved). Set
+> `ONELLM_COREML_DISABLED=false` to opt back in.
+
 > [!IMPORTANT]
 > Short-name aliases like `local/all-MiniLM-L6-v2` and `local/all-mpnet-base-v2` were removed. Use the full HuggingFace repo id (`local/sentence-transformers/all-MiniLM-L6-v2`) or migrate to the new default.
 
@@ -231,6 +236,236 @@ response, _ := formation.ChatWithOptions("Remember I prefer Python", muxi.ChatOp
 [[/tabs]]
 
 Each user's memory is completely isolated.
+
+## Memory Scopes
+
+Memory is no longer single-scope. A memory is **written to exactly one scope**
+and **read up the chain** - a user's query sees their own memories, their
+groups' shared memories, and formation-wide memories, merged by relevance with
+more-specific scopes outranking broader ones.
+
+| Scope | Written by | Read by |
+|-------|-----------|---------|
+| `user` | conversation extraction (always) and explicit writes | that user |
+| `group` | grant-gated shared writes | members of the group |
+| `formation` | grant-gated shared writes | everyone |
+
+Writing `group` or `formation` scope requires a `memory.write` grant in the
+caller's [group YAML](../concepts/access-control.md#shared-memory-grants) (403
+without one). Set `scope_id` to the group ID for group writes; formation writes
+derive their scope ID from the active formation. `GET /v1/memories` can narrow
+the fan-out with the comma-separated `scopes` query parameter, for example
+`?scopes=user` or `?scopes=user,group`.
+
+```json
+{
+  "content": "The support team owns production triage.",
+  "scope": "group",
+  "scope_id": "support"
+}
+```
+
+## Ingestion API
+
+Push content into memory from pipelines and integrations, not just chat:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /v1/memories` | Ingest one item (`source`, `source_id`, `timestamp`, `metadata`, scope fields) |
+| `POST /v1/memories/batch` | Batch ingest with per-item accepted/duplicate/invalid status |
+| `GET /v1/memories/ingestion/{processing_id}` | Async status with per-stage outcomes and cost |
+
+Ingestion is **idempotent by construction**: `(source, source_id)` rides a unique
+index, so a replayed POST returns the original event id (`duplicate: true`) and
+never creates copies. A cheap local classifier triages items and per-source noise
+filtering (`memory.ingestion.sources.<source>.filter`) runs before extraction;
+filtered items are recorded as replayable events.
+
+Ingestion behaviour is tuned through the `memory.ingestion` block (inert when
+absent):
+
+```yaml
+memory:
+  ingestion:
+    sources:
+      zendesk:
+        filter: strict         # strict | lenient | off; strict is default
+        tier: 2                # pin a source's processing tier
+    tiers:
+      enabled: true
+      ambiguity_margin: 0.05
+      t3_signal_score: 5
+      models:
+        t2: openai/gpt-4o-mini
+        t3: openai/gpt-4o      # optional frontier model for high-signal items
+      budget:
+        t2_items_per_job: 100  # capped items are demoted, not dropped
+        t3_items_per_job: 10
+    entity_resolution:
+      enabled: true
+      auto_merge_threshold: 0.85
+      flag_threshold: 0.5
+      entity_types: [person]
+      max_entities: 200
+    synthesis:
+      enabled: true
+      hot: { enabled: true, interval_seconds: 300 }
+      warm: { enabled: true, interval_seconds: 3600 }
+      cold: { enabled: true, interval_seconds: 86400 }
+      cold_cold: { enabled: true, interval_seconds: 604800 }
+      patterns:
+        enabled: true
+        min_events: 20
+        top_k: 3
+```
+
+Items escalate through tiers (Tier 0 regex signals → Tier 1 verbatim →
+Tier 2 LLM extraction → Tier 3 frontier model) based on deterministic
+heuristics; `metadata.priority: high` forces Tier 3. Entity resolution merges
+probable identity matches over the knowledge graph. Each synthesis cadence is
+individually disableable and interval-configurable.
+
+### Distillery
+
+On-prem distilleries can push pre-processed memory through a signed channel:
+
+```yaml
+memory:
+  distillery:
+    enabled: true
+    default_trust_level: provisional   # provisional | verified
+    default_max_batch_size: 10000
+    default_max_events_per_day: 1000000
+    signature_max_age_seconds: 300
+```
+
+The feature also requires persistent memory with `memory.events.enabled`.
+Manage the Ed25519 trust registry through the admin API:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /v1/memory/distilleries` | Register a public key, trust level, and write scope |
+| `GET /v1/memory/distilleries` | List registrations |
+| `DELETE /v1/memory/distilleries/{distillery_id}` | Revoke a registration |
+| `POST /v1/memories/distilled` | Submit a signed batch |
+| `GET /v1/memories/distilled/{processing_id}` | Poll projection/embedding status |
+
+A registration scope can restrict `user_ids` (`all`, `pattern:<glob>`, or an
+explicit list), `event_types`, `max_events_per_day`, and `max_batch_size`.
+Submissions carry `X-Distillery-ID`, `X-Distillery-Signature`, and
+`X-Distillery-Timestamp`. Authentication is fail-closed Ed25519 over the raw
+body bound to id and timestamp. Unknown or invalid credentials return the same
+401, revoked registrations return 410, and quota exhaustion returns 429.
+
+```json
+{
+  "batch_id": "distill-20260713-001",
+  "embedding_mode": "none",
+  "events": [
+    {
+      "event_type": "fact.extracted",
+      "event_version": 1,
+      "user_id": "user_123",
+      "source_id": "ticket-9482:fact-1",
+      "occurred_at": "2026-07-13T12:00:00Z",
+      "payload": {
+        "memory": "The user prefers email notifications.",
+        "collection": "preferences"
+      }
+    }
+  ]
+}
+```
+
+Accepted event types are `fact.extracted`, `log.entry`, and
+`interaction.turn`. To ship vectors, use `embedding_mode: "pre_computed"`,
+provide a provider-prefixed `embedding_model`, and map payload field names to
+float arrays in each event's `embedding_vectors`.
+
+## Event Substrate
+
+Every memory write is recorded as an immutable event; the stores are rebuildable
+projections.
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /v1/memories/provenance?entity=X` | "Why do you think X?" - entity, facts, and causation chains back to the source turn (`?event_id=` traces one event) |
+| `POST /v1/memory/rebuild` | Wipe-and-rebuild projections (background job by default; backs `muxi memory rebuild --user <id>`) |
+| `POST /v1/memory/backfill` | Synthesize `source='legacy'` events for pre-event-log rows |
+| `POST /v1/memory/forget` | GDPR flow: soft-delete a source's events and start a projection rebuild |
+| `GET /v1/memory/forget/{job_id}` | Poll the default background rebuild |
+
+Use `background: false` in the forget request body or `?sync=true` to wait for
+the rebuild. Legacy backfill processes bounded resumable passes and reports
+`synthesized` plus `complete` for each projection.
+
+```yaml
+memory:
+  events:
+    event_first: false      # Phase C cutover groundwork, default OFF
+    retention:
+      max_events_per_user: 100000   # alert-only
+  decay:
+    enabled: true
+    default_half_life_days: 180
+    volatile_default_ttl_hours: 24
+    half_lives: {}          # per-relationship-type overrides
+  projections:
+    batch_size: 500
+    lag_alert_threshold_seconds: 60
+```
+
+## Knowledge Graph & Captain's Log
+
+Built alongside (not replacing) flat-fact extraction:
+
+- **Knowledge graph** (`kg_entities` / `kg_relationships`): real-time + hourly
+  deep extraction, contradiction detection with supersession (retain-never-
+  delete), and graph context injected into chat.
+- **Captain's Log**: periodic per-user digests with full source lineage, exposed
+  via the `/history` client endpoint. A session-end digest fires when a session
+  idles past `memory.captains_log.session_idle_minutes` (default `30`, `0`/`false`
+  disables), so short sessions persist without waiting for the daily tick.
+- **Lessons loop**: digest-extracted lessons with dedup, confidence decay, a
+  `record_lesson` built-in tool, and top-N injection into agent prompts.
+- **Recall**: the `recall_history` built-in tool answers time-anchored questions
+  ("what did we discuss last Tuesday?") over the user's own log entries.
+
+```yaml
+memory:
+  captains_log:
+    session_idle_minutes: 30
+```
+
+## Lifecycle & Maintenance
+
+All four blocks fail-fast validate at load and are inert when unconfigured:
+
+```yaml
+memory:
+  compaction:
+    flush_enabled: true
+    flush_threshold: 0.80     # pre-compaction flush of at-risk buffer items
+  pruning:
+    mode: cache-ttl           # trim stale context after the prompt-cache window
+    strategy: soft_trim       # soft_trim | hard_clear
+    cache_ttl_seconds: 300
+    keep_last_n_tool_results: 3
+    soft_trim_max_chars: 4000
+  index:
+    enabled: true
+    entity_count_threshold: 10   # regenerate after this entity-count change
+    max_tokens: 300
+    artifact_cap: 20
+    regenerate_on: [artifact_save, entity_count_threshold, lint, log_entry]
+  lint:
+    enabled: true
+    schedule: weekly              # daily | weekly | positive seconds
+    conflict_resolution_days: 7   # on demand: POST /v1/memory/lint
+    stale_artifact_days: 90
+    superseded_retention_days: 30
+    orphan_cleanup: true
+```
 
 ## Complete Configuration
 

--- a/docs/reference/response-ui-widgets.md
+++ b/docs/reference/response-ui-widgets.md
@@ -1,0 +1,248 @@
+---
+title: Response UI Widgets
+description: Optional typed affordances the runtime attaches to chat responses
+---
+
+# Response UI Widgets
+
+## Optional, typed affordances on a chat response
+
+A chat response can carry an optional `ui` array of **widgets** - small, typed
+affordances a client can render natively: a set of choices to pick from, a link
+to send the user somewhere, or a UI resource relayed from an MCP server.
+
+The runtime never renders anything. Clients that understand a widget type render
+it; clients that don't ignore it. The response `text` always carries the
+fallback, so the interaction works even with no widget support at all. Treat
+unknown widget types as a no-op (progressive enhancement) - never as an error.
+
+> [!NOTE]
+> Widgets are produced only by trusted runtime producers (formation config, tool
+> results, clarification state, MCP servers), never from free-form LLM output. This
+> is what makes an `action_link` URL safe to render: it can only reach a widget
+> through a producer that names its source.
+
+
+## How widgets arrive
+
+For non-streaming chat, widgets appear in the response message's optional
+`ui` array. For streaming chat, they ride a dedicated `event: ui` SSE frame
+emitted at end-of-turn, just before `event: done`:
+
+```
+data: {"token": "Which region should I use?"}
+
+event: ui
+data: {"ui": [{"type": "options", "id": "ui_a1b2c3", "prompt": "Which region?", "options": [{"value": "us", "label": "United States"}, {"value": "eu", "label": "Europe"}], "multi": false}]}
+
+event: done
+data: {"finished": true}
+```
+
+A turn with no widgets is byte-identical to a stream that never had this
+feature - the `event: ui` frame is simply absent.
+
+In a non-streaming response with no widgets, the message omits `ui` rather than
+serializing it as `null` or an empty array.
+
+
+## Widget types
+
+### `options`
+
+A short question with choices to pick from instead of typing.
+
+```json
+{
+  "type": "options",
+  "id": "ui_a1b2c3d4e5f6g7h8i9j0k",
+  "prompt": "Which region should I deploy to?",
+  "options": [
+    { "value": "us", "label": "United States" },
+    { "value": "eu", "label": "Europe" }
+  ],
+  "multi": false
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | Always `"options"` |
+| `id` | string | Runtime-assigned widget id (`ui_` + nanoid); use it on the reply path |
+| `prompt` | string | Short question the options answer |
+| `options` | array | `{value, label}` items (up to 25); `label` falls back to `value` |
+| `multi` | bool | Whether multiple options may be selected (currently always `false`) |
+
+### `action_link`
+
+Send the user somewhere external - a credential portal, OAuth consent screen, or
+dashboard.
+
+```json
+{
+  "type": "action_link",
+  "id": "ui_k0j9i8h7g6f5e4d3c2b1a",
+  "label": "Connect GitHub",
+  "url": "https://github.com/login/oauth/authorize?...",
+  "hint": "Opens GitHub to authorize access"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | Always `"action_link"` |
+| `id` | string | Runtime-assigned widget id |
+| `label` | string | Button/link text |
+| `url` | string | Destination (only `http`/`https` URLs are ever emitted) |
+| `hint` | string | Optional secondary text |
+
+### `mcp_resource`
+
+A gateway passthrough of an MCP App / UI resource returned by an external MCP
+server. MUXI relays the embedded `ui://` resource **verbatim** - no rendering,
+no interpretation, no execution. It is untrusted external content; the producing
+server and tool are recorded on the widget as provenance.
+
+```json
+{
+  "type": "mcp_resource",
+  "id": "ui_z9y8x7w6v5u4t3s2r1q0p",
+  "resource": "ui://weather-card",
+  "data": "<!doctype html>...",
+  "server": "weather-mcp",
+  "tool": "get_forecast",
+  "mime_type": "text/html",
+  "encoding": "base64"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | Always `"mcp_resource"` |
+| `id` | string | Runtime-assigned widget id |
+| `resource` | string | The resource URI (only the `ui://` scheme is accepted) |
+| `data` | string | Embedded content, verbatim (text, or base64 blob) |
+| `server` | string | MCP server id that returned the resource (provenance) |
+| `tool` | string | Tool name whose result carried the resource (provenance) |
+| `mime_type` | string | Declared mimeType, when present |
+| `encoding` | string | `"text"` (default, omitted on the wire) or `"base64"` |
+
+
+## Producing widgets
+
+Widgets can only be created by trusted producers - never from free-form LLM
+output. This is what makes an `action_link` URL safe to render.
+
+- **`options`** - produced automatically by [clarifications](../concepts/clarification.md)
+  that offer enumerable choices (e.g. credential account selection).
+- **`action_link`** - a URL can only enter a widget through a producer that
+  names its source:
+  - A top-level `links:` formation section maps a name to a link, surfaced on
+    credential-redirect responses:
+    ```yaml
+    # formation.afs
+    links:
+      github:
+        label: "Connect GitHub"
+        url: "https://github.com/login/oauth/authorize?..."
+        hint: "Opens GitHub to authorize access"
+    ```
+    Use the credential service name as the key, or `credential_portal` as a
+    generic fallback.
+  - A tool result may carry a `_link` key (mirroring the `_artifact` convention)
+    to surface an action link produced by a tool.
+- **`mcp_resource`** - relayed verbatim when an external MCP tool result carries
+  an embedded `ui://` resource block. No configuration; provenance (server +
+  tool) is recorded on the widget.
+
+## Replying to a widget
+
+An `options` widget that came from a clarification can be answered on the next
+turn. Send the selected value back as a `ui_response` hint alongside the message
+text (the text is always sufficient on its own; the hint just pins the choice
+deterministically):
+
+```json
+{
+  "message": "United States",
+  "ui_response": { "id": "ui_a1b2c3d4e5f6g7h8i9j0k", "value": "us" }
+}
+```
+
+The runtime resolves the hint only when `id` matches the widget that asked the
+question **and** `value` is one of the offered options. Unknown or stale ids are
+ignored and the message stands alone. The runtime stays stateless - there is no
+server-side widget store.
+
+## Channel-native rendering
+
+The bundled Telegram, Slack, and Discord transformers render `options` and
+`action_link` widgets as native buttons while preserving the complete text
+fallback. Email remains text-only. Formation-local transformer files are
+unchanged unless they explicitly use the channel UI namespace:
+
+| Channel | Template value |
+|---------|----------------|
+| Telegram | `${{ ui.telegram.reply_markup }}` |
+| Slack | `${{ ui.slack.blocks }}` |
+| Discord | `${{ ui.discord.components }}` |
+
+Option callbacks encode `<widget_id>#<option_index>`, keeping Telegram callback
+data within its 64-byte limit and avoiding server-side widget storage. Configure
+the inbound trigger's `parse.ui_response` path to round-trip button presses:
+
+```yaml
+# Telegram
+parse:
+  ui_response: "$.callback_query.data"
+
+# Slack
+parse:
+  ui_response: "$.actions[0].value"
+
+# Discord
+parse:
+  ui_response: "$.data.custom_id"
+```
+
+Foreign callback values decode to no hint, so the accompanying message still
+stands alone. Discord component buttons require a bot/application bridge;
+plain Discord webhooks cannot send components.
+
+
+## SDK helpers
+
+The SDKs surface widgets idiomatically:
+
+- **Go** decodes the frame into `ChatChunk.UI` (`[]UIWidget` with typed
+  `UIOption`s).
+- **TypeScript** yields the frame as a chunk of `{ type: "ui", ui: UIWidget[] }`
+  (`UIWidget`/`UIOption` interfaces exported).
+- **Python, Ruby, PHP, C#, Java, Kotlin, Swift, Dart, Rust, C++** expose a
+  `parse_ui_widgets` / `parseUiWidgets` helper that extracts the widgets array
+  from a `ui` stream frame and returns empty for any other or malformed frame.
+
+See the [SDK reference](../sdks/README.md) for per-language signatures.
+
+
+## Size limits
+
+Widgets are clamped so a misbehaving producer cannot bloat responses. Oversized
+widgets are dropped whole (never truncated - the text fallback is always
+complete):
+
+| Limit | Default |
+|-------|---------|
+| Widgets per envelope | 8 |
+| Bytes per standard widget | 4 KB |
+| Combined standard-widget bytes | 16 KB |
+| Options per `options` widget | 25 |
+| Bytes per `mcp_resource` widget | 64 KB |
+| Combined `mcp_resource` bytes | 128 KB |
+
+
+## Learn More
+
+- [Build Custom UI](../guides/build-custom-ui.md) - render widgets in a frontend
+- [Real-Time Streaming](../deep-dives/real-time-streaming.md) - SSE event stream
+- [Clarifications](../concepts/clarification.md) - where `options` widgets come from

--- a/docs/reference/schema-guide.md
+++ b/docs/reference/schema-guide.md
@@ -272,11 +272,13 @@ a2a:
   enabled: true
   outbound:
     enabled: true
-    timeout_seconds: 30
-    max_retries: 3
+    default_timeout_seconds: 30
+    default_retry_attempts: 3
   inbound:
     enabled: true
-    require_auth: true
+    auth:
+      type: bearer
+      token: "${{ secrets.A2A_TOKEN }}"
 ```
 
 [More: A2A Services Reference →](a2a.md)
@@ -517,39 +519,20 @@ id: "analytics-engine"
 name: "Analytics Engine"
 description: "External analytics service"
 
-endpoint: "https://analytics.example.com"
-protocol: https
+url: "https://analytics.example.com"
 version: "1.0.0"
+active: true
 
 timeout_seconds: 30
 retry_attempts: 3
-retry_delay_seconds: 1
-retry_backoff_multiplier: 2.0
 
 auth:
   type: bearer
   token: "${{ secrets.ANALYTICS_TOKEN }}"
 
-rate_limiting:
-  requests_per_minute: 100
-  burst_limit: 20
-
-health_check:
-  enabled: true
-  endpoint: "/health"
-  interval_seconds: 60
-
-circuit_breaker:
-  enabled: true
-  failure_threshold: 5
-  success_threshold: 2
-  timeout_seconds: 60
-
-capabilities:
-  agents: ["analytics-agent", "reporting-agent"]
-  features: ["analysis", "visualization"]
-  streaming: true
-  async: true
+author: "Data Team"
+documentation: "https://docs.analytics.example.com"
+support_contact: "data-team@example.com"
 ```
 
 [More: A2A Services Reference →](a2a.md)

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -286,7 +286,28 @@ Agent: [Activates file-generation → runs generate.py]
 Agent: [Returns chart image]
 ```
 
-Built-in skills can be disabled in the formation config if not needed.
+### compute
+
+A code-as-reasoning skill: the agent writes a self-contained Python file and a
+bundled executor runs it inside the Skill RCE sandbox - no inner LLM loop, no
+orchestration. `SKILL.md` teaches the write-file/print-answer contract and the
+allowed-imports policy (`json`, `math`, `datetime`, `re`, `statistics`, `csv`,
+plus inlined `pandas`/`numpy`); four worked reference examples ship with it.
+
+The executor is hardened (path-traversal and symlink rejection, AST
+import/builtin policy that follows attribute chains, distinct machine-readable
+error prefixes so syntax and import violations are reported separately), and
+emits `computation.{requested,completed,failed}` events with a `failure_kind`
+breakdown. It degrades like any scripted skill when no RCE is configured.
+
+Built-in skills can be disabled in the formation config via
+`skills.disable_builtin` if not needed:
+
+```yaml
+skills:
+  disable_builtin:
+    - compute
+```
 
 
 ## REST API

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -126,9 +126,9 @@ auth:
 | `retry_attempts` | int | - | Number of retries (0-10) |
 | `connection_ttl` | int | - | Per-server idle TTL override (seconds). See [Connection Lifecycle](#connection-lifecycle). |
 | `parameters` | object | - | Default tool arguments injected into every call. See [Default Parameters](#default-parameters). |
-| `tools` | object | - | Filter the agent-visible tool surface advertised by this MCP server. See [Tool Filtering](#tool-filtering-whitelist--blacklist). |
+| `tools` | object | - | Filter the agent-visible tool surface advertised by this MCP server. See [Tool Filtering](#tool-filtering-allow--deny). |
 
-### Tool Filtering (whitelist / blacklist)
+### Tool Filtering (`allow` / `deny`)
 
 Large MCP servers (Microsoft 365, Google Workspace, ms365-assistant, large internal catalogs) often expose 30+ tools, of which any given agent only needs a handful. Filtering trims the surface advertised to the LLM at registration time, so the planning prompt shrinks and the model is less likely to pick a wrong-but-plausible tool.
 
@@ -144,7 +144,7 @@ auth:
   ACCESS_TOKEN: "${{ user.credentials.MS365 }}"
 
 tools:
-  whitelist:
+  allow:
     - "list-excel-files"
     - "read-excel-*"
     - "update-excel-*"
@@ -154,18 +154,42 @@ tools:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `tools.whitelist` | string[] | If set, **only** these tool names are exposed. fnmatch-style globs (`*`, `?`) supported. |
-| `tools.blacklist` | string[] | If set, every tool **except** these is exposed. Same glob syntax. |
+| `tools.allow` | string[] | If set, **only** these tool names are exposed. fnmatch-style globs (`*`, `?`) supported. |
+| `tools.deny` | string[] | These tool names are hidden. Same glob syntax. Applied **after** `allow`. |
 
-> [!IMPORTANT]
-> `whitelist` and `blacklist` are mutually exclusive. Setting both at the same time fails formation validation at load time.
+> [!NOTE]
+> `allow` / `deny` is the canonical vocabulary at every level; `whitelist` /
+> `blacklist` remain accepted aliases. `allow` and `deny` may now be combined
+> (deny is applied after allow) - the old strict either-or rule is relaxed.
+
+`tools:` overrides cascade across four levels, most specific wins:
+
+1. MCP registry catalog (`mcp.servers[].tools`)
+2. **Agent attachment** - an agent's `mcp_servers` entry may be a `{id, tools}`
+   mapping instead of a bare string
+3. Group per-server
+4. Group per-agent-per-server
+
+```yaml
+# agents/researcher.afs
+mcp_servers:
+  - id: web-search
+    tools:
+      allow: ["search"]
+      deny: ["admin_*"]
+```
+
+An intentionally emptied shared catalog is respected as empty (no silent
+fall-through to the unfiltered registry). `tools: {deny: "*"}` hides a server
+entirely. See [Access Control](../concepts/access-control.md) for the group
+levels.
 
 #### How it's applied
 
 ```
 Upstream MCP tools/list response
         ↓
-   Filter (whitelist or blacklist, fnmatch globs)
+   Filter (allow, then deny; fnmatch globs)
         ↓
 Agent-visible tool registry (this is what the LLM ever sees)
 ```
@@ -176,14 +200,14 @@ The filter runs on every MCP `tools/list` refresh, so dynamic tool catalogs stay
 
 | Goal | Pattern |
 |------|---------|
-| Read-only access to a domain | `whitelist: ["list-*", "read-*", "search-*"]` |
-| Block destructive operations | `blacklist: ["delete-*", "drop-*", "purge-*"]` |
-| Single-tool agent | `whitelist: ["search-web"]` |
-| Per-domain split of a large catalog | One MCP file per domain (excel/word/email/calendar), each with its own `whitelist` |
+| Read-only access to a domain | `allow: ["list-*", "read-*", "search-*"]` |
+| Block destructive operations | `deny: ["delete-*", "drop-*", "purge-*"]` |
+| Single-tool agent | `allow: ["search-web"]` |
+| Per-domain split of a large catalog | One MCP file per domain (excel/word/email/calendar), each with its own `allow` |
 
 #### Per-domain split for large catalogs
 
-For MCPs with >20 tools, the recommended pattern is to define **one MCP `.afs` file per domain**, each scoped to the appropriate agent, instead of giving every agent the full catalog. Example: `ms365-excel.afs` (whitelisted to Excel tools) → `ms365-excel-agent.afs`; `ms365-email.afs` → `ms365-email-agent.afs`. The full upstream MCP server still runs once per agent, but each agent's tool surface is a curated slice. See the [multi-agent guide](../guides/build-multi-agent-systems.md#per-agent-mcp-scoping-for-large-catalogs) for a worked example.
+For MCPs with >20 tools, the recommended pattern is to define **one MCP `.afs` file per domain**, each scoped to the appropriate agent, instead of giving every agent the full catalog. Example: `ms365-excel.afs` (allowed Excel tools only) → `ms365-excel-agent.afs`; `ms365-email.afs` → `ms365-email-agent.afs`. The full upstream MCP server still runs once per agent, but each agent's tool surface is a curated slice. See the [multi-agent guide](../guides/build-multi-agent-systems.md#per-agent-mcp-scoping-for-large-catalogs) for a worked example.
 
 ### Capabilities
 
@@ -223,6 +247,52 @@ metadata:
   documentation: "https://docs.example.com"
   tags: ["search", "web"]
 ```
+
+## Built-in Tools
+
+Beyond MCP servers, MUXI registers built-in tools automatically when the
+relevant feature is configured. Agents call them like any other tool.
+
+| Tool | Available when | Purpose |
+|------|----------------|---------|
+| `generate_file` | always | Produce a file artifact in the sandbox (see [Artifacts](../concepts/artifacts.md)) |
+| `get_artifact` / `get_artifact_content` / `get_artifact_history` | artifact memory retrieval | Recall, read, and version-walk previously produced artifacts |
+| `watch_job` | the formation declares MCP servers and watch is not disabled | Poll a remote job and re-enter when it completes |
+| `recall_history` | Captain's Log enabled | Time-anchored recall over the user's own log entries (`date_from`/`date_to` ISO dates, optional `query`, `limit`) |
+| `record_lesson` | Captain's Log enabled | Record a durable lesson that is injected into agent prompts |
+| `delegate_coding` | a `coding:` block exists | Delegate a coding task to an external CLI (see [Coding-Agent Delegation](../concepts/coding-delegation.md)); always async |
+
+## Watching remote MCP tools (`watch_job`)
+
+MCP-reachable work that outlives a turn (image/video generation, long renders,
+batch jobs) can be collected instead of forgotten. The agent calls the built-in
+`watch_job` tool, which registers a deterministic poll loop over any MCP tool the
+calling user can see - the poll loop runs no LLM, so polling costs zero tokens.
+`watch_job` is **always async**: it returns a job handle immediately.
+
+Parameters: `tool` (`server.tool`, `server__tool`, or bare name), `args`,
+`done_when` (`path` + `equals`/`in`), optional `result` selector and `label`.
+There are no interval/timeout arguments - cadence and deadline are formation
+config. Jobs appear on the `/jobs` surface; completion, timeout, or failure
+re-enters the conversation (`route_class: watch`) via the notification router.
+Polls run under the original user's permission context (fail-closed).
+
+The `mcp.watch` sub-block configures the loop. `watch_job` is **on by default**
+whenever the formation declares MCP servers; `mcp: {watch: false}` removes the
+tool entirely.
+
+```yaml
+mcp:
+  watch:
+    interval: 30                  # seconds between polls (default 30)
+    timeout: 7200                 # per-job deadline in seconds (default 7200)
+    max_concurrent: 10            # per user (default 10)
+    max_consecutive_failures: 3   # give up after N failed polls (default 3)
+```
+
+A bundled recognition SOP fragment teaches agents to spot job-shaped responses;
+a formation-local `sops/watch_job.md` shadows it (an empty file removes it).
+Group templates may raise the quota with `mcp: {watch: {max_concurrent: N}}`.
 
 ## Popular MCP Servers
 

--- a/docs/reference/triggers.md
+++ b/docs/reference/triggers.md
@@ -182,6 +182,71 @@ curl -X POST http://localhost:8001/v1/formations/my-formation/triggers/github-is
   }'
 ```
 
+## Transformers: outbound routing
+
+A trigger's result can be delivered to an external platform (Slack, Telegram,
+Twilio, any webhook consumer) with no custom glue. Add `transformer:` to use a
+named payload template. `webhook:` may be used alone for the standard payload or
+together with `transformer:` to override its delivery URL. Use `parse:` to
+extract inbound fields through simple JSON-style paths into the request and
+template context.
+
+```markdown
+<!-- triggers/slack-message.md -->
+---
+transformer: slack
+webhook: https://hooks.example.com/slack-bridge
+parse:
+  message: "$.event.text"
+  user_id: "$.event.user"
+  context:
+    channel: "$.event.channel"
+    thread_ts: "$.event.thread_ts"
+---
+Handle the inbound Slack message.
+```
+
+Transformer YAML files live in `transformers/<name>.yaml` (fail-fast validation)
+and define the outbound payload template, HTTP delivery with
+bearer/basic/header auth, and optional content transformation:
+
+```yaml
+# transformers/slack.yaml
+name: slack
+endpoint:
+  url: "${{ secrets.SLACK_WEBHOOK }}"   # optional; trigger/channel URL wins
+  method: POST
+auth:
+  type: bearer
+  token: "${{ secrets.SLACK_TOKEN }}"
+headers:
+  Content-Type: application/json
+body:
+  channel: "${{ context.channel }}"
+  text: "${{ response.content }}"
+content_transform:
+  format: markdown
+  max_length: 4000
+  truncation_suffix: "..."
+```
+
+URL resolution is trigger/channel URL first, then the transformer's own, with a
+load-time error when neither exists. Delivery failures use the webhook
+manager's retry policy, then fall back to
+the formation's default async webhook with `transformer_error` metadata - a
+broken transformer never loses the trigger result. Markdown-to-HTML link
+substitution only emits anchors for `http(s)` URLs.
+
+Bundled dormant channel transformers (`slack`, `telegram`, `discord`, `email`)
+ship for use with [proactiveness](../concepts/proactiveness.md); a
+formation-local `transformers/` file shadows them.
+
+## Response UI widgets over channels
+
+Triggers can render [response UI widgets](response-ui-widgets.md) natively on
+supporting channels, and inbound payloads carrying a `ui_response` are parsed
+back into the conversation as the user's widget selection.
+
 ## Related
 
 - [Triggers & Webhooks](../concepts/triggers-and-webhooks.md) - Concept overview

--- a/docs/reference/workflows.md
+++ b/docs/reference/workflows.md
@@ -56,6 +56,42 @@ Requests with complexity scores at or above this threshold will present an execu
 
 See [Human-in-the-Loop](../concepts/human-in-the-loop.md) for details.
 
+## Workflow-level replanning
+
+When a workflow fails after task-level recovery is exhausted, the runtime can
+analyze *why* and ask the decomposer for a fundamentally different plan instead
+of returning the failure. Disabled by default.
+
+```yaml
+overlord:
+  workflow:
+    replanning:
+      enabled: false          # opt in
+      max_attempts: 3         # per original workflow (replans of replans share this budget)
+      plan_similarity_threshold: 0.7
+      preserve_successful_outputs: true
+      replan_timeout_seconds: 30
+      non_replannable_error_patterns:
+        - auth
+        - unauthorized
+        - forbidden
+        - permission
+        - credential
+        - configuration error
+        - invalid api key
+        - data corruption
+```
+
+- Non-replannable errors (auth, permissions, credentials, configuration, data
+  corruption) never trigger a replan - a different plan hits the same wall.
+- Replanned executions run within the *remaining* time budget of the original
+  workflow, never a fresh ceiling.
+- Completed work travels into the replan context so the new plan does not redo
+  it.
+- When disabled, the decomposition prompt stays byte-identical to before.
+- Emits `workflow.replanning.{started,completed,failed,skipped}` events and
+  streaming stages.
+
 ## Complexity Calculation
 
 ### complexity_method

--- a/docs/sdks/README.md
+++ b/docs/sdks/README.md
@@ -451,12 +451,19 @@ All SDKs provide two clients:
 For interacting with a running formation:
 
 - Chat (streaming & non-streaming)
+- [Response UI widgets](../reference/response-ui-widgets.md) (choices, links, MCP UI resources)
 - Sessions & history
 - Memory management
 - Triggers & scheduled tasks
 - Agent configuration
 
 **Authentication:** Client key (`X-Muxi-Client-Key`) or Admin key (`X-Muxi-Admin-Key`)
+
+> [!NOTE]
+> All SDKs auto-send an `X-Muxi-Idempotency-Key`. Successful non-streaming
+> mutations can be replayed safely; streams and failed requests execute again.
+> Cached responses expose the echoed key on the unwrapped result. See
+> [Idempotency](../deep-dives/idempotency.md).
 
 > [!TIP]
 > **Browser usage:** The TypeScript SDK's FormationClient works directly in browsers. Use the `clientKey` for browser apps - it's safe to expose and has limited permissions. Keep the `adminKey` server-side only.

--- a/docs/sdks/cpp-sdk.md
+++ b/docs/sdks/cpp-sdk.md
@@ -173,6 +173,21 @@ add_executable(my_app main.cpp)
 target_link_libraries(my_app PRIVATE muxi::muxi)
 ```
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources) on a `ui` event. Extract them with the
+`parse_ui_widgets(event)` free function; it returns an empty array for any
+non-`ui` or malformed event, so unknown widgets are safely ignored.
+
+## Idempotency
+
+The client auto-generates an `X-Muxi-Idempotency-Key` on every request, so a
+retry of a successful non-streaming mutation replays the original response.
+Streaming and failed requests execute again. Cached responses expose the echoed
+`idempotency_key` on the unwrapped result. See
+[Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [Full documentation on GitHub](https://github.com/muxi-ai/muxi-cpp)

--- a/docs/sdks/csharp-sdk.md
+++ b/docs/sdks/csharp-sdk.md
@@ -134,6 +134,21 @@ catch (MuxiException e)
 }
 ```
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources) on a `ui` event. Extract them with
+`FormationClient.ParseUiWidgets(...)`, which returns a `JsonArray` (empty for any
+non-`ui` or malformed event), so unknown widgets are safely ignored.
+
+## Idempotency
+
+The client auto-generates an `X-Muxi-Idempotency-Key` on every request, so a
+retry of a successful non-streaming mutation replays the original response.
+Streaming and failed requests execute again. Cached responses expose the echoed
+`idempotency_key` on the unwrapped result. See
+[Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [Full documentation on GitHub](https://github.com/muxi-ai/muxi-csharp)

--- a/docs/sdks/dart-sdk.md
+++ b/docs/sdks/dart-sdk.md
@@ -168,6 +168,21 @@ class _ChatWidgetState extends State<ChatWidget> {
 }
 ```
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources) on a `ui` event. Extract them with the
+top-level `parseUiWidgets(event)`; it returns an empty list for any non-`ui` or
+malformed event, so unknown widgets are safely ignored.
+
+## Idempotency
+
+The client auto-generates an `X-Muxi-Idempotency-Key` on every request, so a
+retry of a successful non-streaming mutation replays the original response.
+Streaming and failed requests execute again. Cached responses expose the echoed
+`idempotency_key` on the unwrapped result. See
+[Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [Full documentation on GitHub](https://github.com/muxi-ai/muxi-dart)

--- a/docs/sdks/go-sdk.md
+++ b/docs/sdks/go-sdk.md
@@ -421,6 +421,43 @@ func main() {
 ```
 
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources). The Go SDK decodes them into the typed
+`Chunk.UI` field (a `[]UIWidget`, each with typed `UIOption`s) on the `ui` chunk;
+other chunks leave it empty.
+
+```go
+stream, errs := client.ChatStream(ctx, &muxi.ChatRequest{
+    Message: "Which region?",
+    UserID:  "user_123",
+})
+
+for stream != nil {
+    select {
+    case chunk, ok := <-stream:
+        if !ok {
+            stream = nil
+            continue
+        }
+        for _, widget := range chunk.UI {
+            if widget.Type == "options" {
+                fmt.Println(widget.Prompt)
+            }
+        }
+    case err := <-errs:
+        if err != nil {
+            log.Fatal(err)
+        }
+        errs = nil
+    }
+}
+```
+
+The echoed idempotency key is available on the unwrapped response via
+`RequestInfo.IdempotencyKey`. See [Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [Python SDK](python-sdk.md)

--- a/docs/sdks/java-sdk.md
+++ b/docs/sdks/java-sdk.md
@@ -127,6 +127,21 @@ try {
 }
 ```
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources) on a `ui` event. Extract them with the static
+`FormationClient.parseUiWidgets(...)`; it returns an empty list for any non-`ui`
+or malformed event, so unknown widgets are safely ignored.
+
+## Idempotency
+
+The client auto-generates an `X-Muxi-Idempotency-Key` on every request, so a
+retry of a successful non-streaming mutation replays the original response.
+Streaming and failed requests execute again. Cached responses expose the echoed
+`idempotency_key` on the unwrapped result. See
+[Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [Full documentation on GitHub](https://github.com/muxi-ai/muxi-java)

--- a/docs/sdks/kotlin-sdk.md
+++ b/docs/sdks/kotlin-sdk.md
@@ -122,6 +122,21 @@ try {
 }
 ```
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources) on a `ui` event. Extract them with the
+top-level `parseUiWidgets(...)`; it returns an empty list for any non-`ui` or
+malformed event, so unknown widgets are safely ignored.
+
+## Idempotency
+
+The client auto-generates an `X-Muxi-Idempotency-Key` on every request, so a
+retry of a successful non-streaming mutation replays the original response.
+Streaming and failed requests execute again. Cached responses expose the echoed
+`idempotency_key` on the unwrapped result. See
+[Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [Full documentation on GitHub](https://github.com/muxi-ai/muxi-kotlin)

--- a/docs/sdks/php-sdk.md
+++ b/docs/sdks/php-sdk.md
@@ -115,6 +115,21 @@ try {
 }
 ```
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources) on a `ui` event. Extract them with the static
+`FormationClient::parseUiWidgets($event)`; it returns `[]` for any non-`ui` or
+malformed event, so unknown widgets are safely ignored.
+
+## Idempotency
+
+The client auto-generates an `X-Muxi-Idempotency-Key` on every request, so a
+retry of a successful non-streaming mutation replays the original response.
+Streaming and failed requests execute again. Cached responses expose the echoed
+`idempotency_key` on the unwrapped result. See
+[Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [Full documentation on GitHub](https://github.com/muxi-ai/muxi-php)

--- a/docs/sdks/python-sdk.md
+++ b/docs/sdks/python-sdk.md
@@ -378,6 +378,30 @@ while True:
 ```
 
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources) on a `ui` event. Extract them with
+`parse_ui_widgets`; it returns `[]` for any non-`ui` or malformed chunk, so
+unknown widgets are safely ignored.
+
+```python
+from muxi import parse_ui_widgets
+
+for chunk in formation.chat_stream({"message": "Which region?"}, user_id="user_123"):
+    for widget in parse_ui_widgets(chunk):
+        if widget["type"] == "options":
+            print(widget["prompt"])
+```
+
+## Idempotency
+
+The client auto-generates an `X-Muxi-Idempotency-Key` on every request, so a
+retry of a successful non-streaming mutation replays the original response.
+Streaming and failed requests execute again. Cached responses expose the echoed
+`idempotency_key` on the unwrapped result. See
+[Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [TypeScript SDK](typescript-sdk.md)

--- a/docs/sdks/ruby-sdk.md
+++ b/docs/sdks/ruby-sdk.md
@@ -124,6 +124,32 @@ rescue Muxi::MuxiError => e
 end
 ```
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources) on a `ui` event. Extract them with
+`Muxi.parse_ui_widgets`; it returns `[]` for any non-`ui` or malformed event, so
+unknown widgets are safely ignored.
+
+```ruby
+client.chat_stream(message: 'Which region?', user_id: 'user_123') do |event|
+  widgets = Muxi.parse_ui_widgets(event)
+  next if widgets.empty?
+
+  widgets.each do |widget|
+    puts widget['prompt'] if widget['type'] == 'options'
+  end
+end
+```
+
+## Idempotency
+
+The client auto-generates an `X-Muxi-Idempotency-Key` on every request, so a
+retry of a successful non-streaming mutation replays the original response.
+Streaming and failed requests execute again. Cached responses expose the echoed
+`idempotency_key` on the unwrapped result. See
+[Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [Full documentation on GitHub](https://github.com/muxi-ai/muxi-ruby)

--- a/docs/sdks/rust-sdk.md
+++ b/docs/sdks/rust-sdk.md
@@ -149,6 +149,21 @@ Available features:
 - `rustls-tls` - Use rustls for TLS
 - `tracing` - Enable tracing support
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources) on a `ui` event. Extract them with the public
+`parse_ui_widgets(&event)` function; it returns an empty `Vec` for any non-`ui`
+or malformed event, so unknown widgets are safely ignored.
+
+## Idempotency
+
+The client auto-generates an `X-Muxi-Idempotency-Key` on every request, so a
+retry of a successful non-streaming mutation replays the original response.
+Streaming and failed requests execute again. Cached responses expose the echoed
+`idempotency_key` on the unwrapped result. See
+[Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [Full documentation on GitHub](https://github.com/muxi-ai/muxi-rust)

--- a/docs/sdks/swift-sdk.md
+++ b/docs/sdks/swift-sdk.md
@@ -133,6 +133,21 @@ do {
 - watchOS 8.0+
 - Linux (Swift 5.9+)
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources) on a `ui` event. Extract them with the
+`parseUiWidgets(...)` free function; it returns an empty array for any non-`ui`
+or malformed event, so unknown widgets are safely ignored.
+
+## Idempotency
+
+The client auto-generates an `X-Muxi-Idempotency-Key` on every request, so a
+retry of a successful non-streaming mutation replays the original response.
+Streaming and failed requests execute again. Cached responses expose the echoed
+`idempotency_key` on the unwrapped result. See
+[Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [Full documentation on GitHub](https://github.com/muxi-ai/muxi-swift)

--- a/docs/sdks/typescript-sdk.md
+++ b/docs/sdks/typescript-sdk.md
@@ -474,6 +474,26 @@ export async function POST(req: Request) {
 ```
 
 
+## Response UI Widgets
+
+A streamed response can carry optional [UI widgets](../reference/response-ui-widgets.md)
+(choices, links, MCP UI resources). They arrive as a chunk of shape
+`{ type: "ui", ui: UIWidget[] }`; the `UIWidget` and `UIOption` interfaces are
+exported. Ignore widget types you don't render - the text always stands alone.
+
+```typescript
+for await (const chunk of await formation.chatStream({ message: 'Which region?' }, 'user_123')) {
+  if (chunk.type === 'ui') {
+    for (const widget of chunk.ui) {
+      if (widget.type === 'options') console.log(widget.prompt);
+    }
+  }
+}
+```
+
+The echoed idempotency key is surfaced as `idempotency_key` on the unwrapped
+response. See [Idempotency](../deep-dives/idempotency.md).
+
 ## Learn More
 
 - [Python SDK](python-sdk.md)

--- a/docs/server/managing-formations.md
+++ b/docs/server/managing-formations.md
@@ -51,6 +51,20 @@ muxi deploy  # New version starts, old version still serving
 
 If the new version fails health checks, the old version keeps running and the update is automatically aborted.
 
+### Preserved runtime state
+
+An update deploys a new bundle, but some files are **runtime-owned** and belong
+to the running formation, not the bundle. The server preserves these from the
+live version so an update (or rollback) never wipes them:
+
+- `memory.db` - persistent conversation memory
+- `MUXI.md` and `PENDING-MUXI.md` - the formation's self-improvement (tuning)
+  state
+
+The live files always win over any copies carried in the uploaded bundle, and
+they are carried across a [rollback](#rollback) the same way. See
+[Self-Tuning](../concepts/self-tuning.md) for what `MUXI.md` holds.
+
 ## List Formations
 
 ```bash
@@ -125,6 +139,11 @@ The rollback process is instantaneous:
 4. Current version shuts down gracefully
 
 **No requests are dropped during rollback.** The entire process completes in seconds while maintaining full availability.
+
+Rollback preserves the same [runtime-owned state](#preserved-runtime-state) as
+an update: `memory.db` and the tuning files (`MUXI.md`, `PENDING-MUXI.md`) are
+carried from the current version into the restored one, so rolling back the code
+never discards live memory or self-improvement state.
 
 ## View Logs
 


### PR DESCRIPTION
## Summary
- document the complete Runtime, Server, CLI, and SDK `1.20260713.0` release surface
- add guides for access control, coding delegation, proactiveness, self-tuning, idempotency, and response UI widgets
- align A2A docs with canonical `id` plus service `url` matching from muxi-ai/runtime#290
- update reference, concepts, guides, and all 12 SDK pages with source-verified behavior

## Validation
- 43 changed Markdown files structurally validated
- 222 YAML examples parsed successfully
- 93 added local links and 17 anchors validated
- `git diff --check` passed