### PR TITLE
docs: reflect runtime hardening (sandboxed conversion, durable quotas, request_id provenance)

### DIFF
--- a/docs/concepts/knowledge-and-rag.md
+++ b/docs/concepts/knowledge-and-rag.md
@@ -37,7 +37,7 @@ sequenceDiagram
 
 ## Supported Formats
 
-MUXI uses [MarkItDown](https://github.com/microsoft/markitdown) for document conversion - any format MarkItDown supports works with MUXI.
+MUXI uses [MarkItDown](https://github.com/microsoft/markitdown) for document conversion - any format MarkItDown supports works with MUXI. PDFs route to a dedicated pdf-inspector engine, with MarkItDown as fallback. Conversion runs in a sandboxed subprocess with resource limits and a wall-clock timeout; hostile or malformed files are quarantined and skipped instead of affecting the runtime.
 
 ### Common Formats
 

--- a/docs/deep-dives/observability-events.md
+++ b/docs/deep-dives/observability-events.md
@@ -56,6 +56,9 @@ Events for processing documents, images, audio, and other media content types.
 | Event | Level | Description |
 |-------|-------|-------------|
 | `content.document.parsed` | INFO | Document attachment processing |
+| `document.conversion.completed` | INFO | Sandboxed document conversion succeeded (pdf-inspector or MarkItDown) |
+| `document.conversion.quarantined` | WARN | Conversion refused or killed; `quarantine_reason` is one of `timeout`, `memory`, `oversize`, `parser_error`, `encrypted`, `unsupported` |
+| `document.conversion.fallback` | WARN | pdf-inspector failed on a PDF; conversion fell back to sandboxed MarkItDown |
 | `content.image.analyzed` | INFO | Image analysis and vision processing |
 | `content.audio.transcribed` | INFO | Audio transcription |
 | `content.extraction.failed` | ERROR | Content processing failure |

--- a/docs/deep-dives/request-lifecycle.md
+++ b/docs/deep-dives/request-lifecycle.md
@@ -220,6 +220,7 @@ Track request:
 - Multi-turn clarifications reuse same `request_id`
 - Enables complete trace of conversation
 - Simplifies debugging and observability
+- Memory events record the originating `request_id`, so provenance chains link back to the turn that produced them
 
 ---
 

--- a/docs/guides/add-knowledge.md
+++ b/docs/guides/add-knowledge.md
@@ -91,7 +91,9 @@ knowledge:
 
 ## Supported Formats
 
-MUXI uses [MarkItDown](https://github.com/microsoft/markitdown) for document conversion - any format MarkItDown supports works with MUXI.
+MUXI uses [MarkItDown](https://github.com/microsoft/markitdown) for document conversion - any format MarkItDown supports works with MUXI. PDFs route to a dedicated pdf-inspector engine, with MarkItDown as fallback.
+
+Conversion runs in a sandboxed subprocess with resource limits and a wall-clock timeout. Files that time out, exhaust memory, exceed size limits, are encrypted, or crash the parser are quarantined and skipped - indexing continues with the rest of your sources.
 
 | Category | Formats | Notes |
 |----------|---------|-------|

--- a/docs/reference/memory.md
+++ b/docs/reference/memory.md
@@ -372,6 +372,8 @@ Submissions carry `X-Distillery-ID`, `X-Distillery-Signature`, and
 `X-Distillery-Timestamp`. Authentication is fail-closed Ed25519 over the raw
 body bound to id and timestamp. Unknown or invalid credentials return the same
 401, revoked registrations return 410, and quota exhaustion returns 429.
+Daily quotas are stored in the database per (formation, distillery, UTC day),
+so counts survive restarts and are shared across replicas.
 
 ```json
 {
@@ -401,7 +403,9 @@ float arrays in each event's `embedding_vectors`.
 ## Event Substrate
 
 Every memory write is recorded as an immutable event; the stores are rebuildable
-projections.
+projections. Each event also records the `request_id` of the chat turn that
+produced it (null for maintenance, synthesis, and legacy backfill writes),
+surfaced in event dicts and provenance chains.
 
 | Endpoint | Purpose |
 |----------|---------|


### PR DESCRIPTION
Updates the docs for three runtime changes merged to muxi-ai/runtime develop (#303, #304, #305).

## Sandboxed document conversion + PDF routing (runtime #305)

- `docs/deep-dives/observability-events.md`: added the three new conversion events to the Multi-Modal Content Processing table — `document.conversion.completed`, `document.conversion.quarantined` (with the six `quarantine_reason` values: `timeout`, `memory`, `oversize`, `parser_error`, `encrypted`, `unsupported`), and `document.conversion.fallback`.
- `docs/guides/add-knowledge.md` and `docs/concepts/knowledge-and-rag.md`: the "MUXI uses MarkItDown" line now notes PDF routing to pdf-inspector (MarkItDown fallback) and that conversion runs in a sandboxed subprocess with resource limits and a wall-clock timeout; quarantined files are skipped and processing continues.

## Durable distillery quotas (runtime #304)

- `docs/reference/memory.md`: one-line durability note next to the existing 429 sentence — daily quotas are DB-backed per (formation, distillery, UTC day), survive restarts, and are shared across replicas. External contract unchanged.

## request_id on memory events (runtime #303)

- `docs/reference/memory.md` (Event Substrate): each memory event now records the originating chat turn's `request_id` (null for maintenance/synthesis/backfill writes), surfaced in event dicts and provenance chains.
- `docs/deep-dives/request-lifecycle.md`: added a bullet under "Request ID reuse" connecting request_id tracing to memory-event provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)